### PR TITLE
Add settings webhooks list page and UI components

### DIFF
--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-gray-50">{children}</div>;
+}

--- a/src/app/settings/webhooks/page.tsx
+++ b/src/app/settings/webhooks/page.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Button from '@/components/ui/Button';
+import WebhookTable from '@/components/settings/WebhookTable';
+
+export default function WebhooksPage() {
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-gray-900">Webhooks</h1>
+        <Button>Create new webhook</Button>
+      </header>
+      <WebhookTable />
+    </div>
+  );
+}

--- a/src/components/settings/WebhookTable.tsx
+++ b/src/components/settings/WebhookTable.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Table from '@/components/ui/Table';
+
+type Webhook = {
+  id: number;
+  name: string;
+  url: string;
+  triggers: string;
+  status: 'Enabled' | 'Disabled';
+};
+
+const webhooks: Webhook[] = [
+  {
+    id: 1,
+    name: 'Send email',
+    url: 'https://example.com/email',
+    triggers: 'entry.create',
+    status: 'Enabled',
+  },
+  {
+    id: 2,
+    name: 'Indexing service',
+    url: 'https://example.com/index',
+    triggers: 'entry.update',
+    status: 'Disabled',
+  },
+];
+
+export default function WebhookTable() {
+  const headers = ['Name', 'URL', 'Triggers', 'Status'];
+  const rows = webhooks.map((w) => [w.name, w.url, w.triggers, w.status]);
+
+  return <Table headers={headers} rows={rows} />;
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: React.ReactNode;
+};
+
+export default function Button({ children, className = '', ...rest }: ButtonProps) {
+  return (
+    <button
+      className={`rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 ${className}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+type TableProps = {
+  headers: string[];
+  rows: React.ReactNode[][];
+};
+
+export default function Table({ headers, rows }: TableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full border border-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            {headers.map((h) => (
+              <th key={h} className="px-4 py-2 text-left text-sm font-semibold text-gray-700">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {rows.map((row, idx) => (
+            <tr key={idx}>
+              {row.map((cell, cIdx) => (
+                <td key={cIdx} className="px-4 py-2 text-sm text-gray-900">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- set up settings routes and layout structure
- add Button and Table UI components
- implement Webhooks list page with sample data

## Testing
- `npm run lint` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c20008cc448332b4b12749f05202f4