### PR TITLE
Add table cell props support and fix table typing

### DIFF
--- a/src/app/(admin)/(rgs)/games/BasicTable.tsx
+++ b/src/app/(admin)/(rgs)/games/BasicTable.tsx
@@ -48,7 +48,7 @@ interface TableConfig<T> {
   getRowKey?: (row: T, index: number) => string | number;
 }
 
-interface ConfigurableTableProps<T> {
+interface ConfigurableTableProps<T extends Record<string, unknown>> {
   data: T[];
   config: TableConfig<T>;
 }

--- a/src/components/ui/table/index.tsx
+++ b/src/components/ui/table/index.tsx
@@ -29,6 +29,8 @@ interface TableCellProps {
   children: ReactNode; // Cell content
   isHeader?: boolean; // If true, renders as <th>, otherwise <td>
   className?: string; // Optional className for styling
+  colSpan?: number; // Optional colspan support for table cells
+  onClick?: React.MouseEventHandler<HTMLTableCellElement>; // Optional click handler
 }
 
 // Table Component
@@ -56,9 +58,22 @@ const TableCell: React.FC<TableCellProps> = ({
   children,
   isHeader = false,
   className,
+  colSpan,
+  onClick,
 }) => {
-  const CellTag = isHeader ? "th" : "td";
-  return <CellTag className={` ${className}`}>{children}</CellTag>;
+  if (isHeader) {
+    return (
+      <th className={` ${className}`} colSpan={colSpan} onClick={onClick}>
+        {children}
+      </th>
+    );
+  }
+
+  return (
+    <td className={` ${className}`} colSpan={colSpan} onClick={onClick}>
+      {children}
+    </td>
+  );
 };
 
 export { Table, TableHeader, TableBody, TableRow, TableCell };


### PR DESCRIPTION
## Summary
- add optional colSpan and onClick props to the shared TableCell component
- constrain ConfigurableTable props to records to satisfy the table configuration typing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb091cb184833290efe91b7d76a33d