### PR TITLE
Fix server/client boundary for configurable tables

### DIFF
--- a/src/app/(admin)/(others-pages)/(tables)/basic-tables/page.tsx
+++ b/src/app/(admin)/(others-pages)/(tables)/basic-tables/page.tsx
@@ -2,8 +2,7 @@ import ComponentCard from "@/components/common/ComponentCard";
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
 import { Metadata } from "next";
 import React from "react";
-import ConfigurableTable from "@/components/tables/ConfigurableTable";
-import { orderTableConfig, orders } from "@/data/dummyTableData";
+import OrdersTable from "@/components/tables/OrdersTable";
 
 export const metadata: Metadata = {
     title: "Next.js Basic Table | TailAdmin - Next.js Dashboard Template",
@@ -18,7 +17,7 @@ export default function BasicTables() {
             <PageBreadcrumb pageTitle="Basic Table"/>
             <div className="space-y-6">
                 <ComponentCard title="Basic Table 1">
-                    <ConfigurableTable data={orders} config={orderTableConfig} />
+                    <OrdersTable />
                 </ComponentCard>
             </div>
         </div>

--- a/src/app/(admin)/(rgs)/games/page.tsx
+++ b/src/app/(admin)/(rgs)/games/page.tsx
@@ -2,8 +2,7 @@ import PageBreadcrumb from "@/components/common/PageBreadCrumb";
 import { Metadata } from "next";
 import React from "react";
 import ComponentCard from "@/components/common/ComponentCard";
-import ConfigurableTable from "@/components/tables/ConfigurableTable";
-import { orderTableConfig, orders } from "@/data/dummyTableData";
+import OrdersTable from "@/components/tables/OrdersTable";
 
 export const metadata: Metadata = {
     title: "Next.js Blank Page | TailAdmin - Next.js Dashboard Template",
@@ -16,7 +15,7 @@ export default function GamesPage() {
             <PageBreadcrumb pageTitle="All Games" />
             <div className="space-y-6">
                 <ComponentCard title="Games">
-                    <ConfigurableTable data={orders} config={orderTableConfig} />
+                    <OrdersTable />
                 </ComponentCard>
             </div>
         </div>

--- a/src/components/tables/OrdersTable.tsx
+++ b/src/components/tables/OrdersTable.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import ConfigurableTable from "@/components/tables/ConfigurableTable";
+import { orderTableConfig, orders } from "@/data/dummyTableData";
+
+const OrdersTable = () => {
+  return <ConfigurableTable data={orders} config={orderTableConfig} />;
+};
+
+export default OrdersTable;

--- a/src/data/dummyTableData.tsx
+++ b/src/data/dummyTableData.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Image from "next/image";
 import Badge from "@/components/ui/badge/Badge";


### PR DESCRIPTION
## Summary
- add a client-side OrdersTable wrapper for the configurable table setup
- update games and basic tables pages to render the client wrapper instead of passing configs from server components
- mark the dummy table data module as a client module so it can be consumed safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb1e97610c8332a87b98026696db89