### PR TITLE
Fetch games list from backend API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL for the FiG backend API
+NEXT_PUBLIC_API_BASE_URL=http://builder-web.192.168.49.2.nip.io

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/app/(admin)/(rgs)/games/page.tsx
+++ b/src/app/(admin)/(rgs)/games/page.tsx
@@ -1,21 +1,23 @@
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
 import { Metadata } from "next";
-import React from "react";
 import ComponentCard from "@/components/common/ComponentCard";
 import OrdersTable from "@/components/tables/OrdersTable";
+import { fetchGames } from "@/lib/games";
 
 export const metadata: Metadata = {
     title: "FiG | All Games",
     description: "All Games page",
 };
 
-export default function GamesPage() {
+export default async function GamesPage() {
+    const games = await fetchGames();
+
     return (
         <div>
             <PageBreadcrumb pageTitle="All Games" />
             <div className="space-y-6">
                 <ComponentCard title="Games">
-                    <OrdersTable />
+                    <OrdersTable data={games} />
                 </ComponentCard>
             </div>
         </div>

--- a/src/components/tables/OrdersTable.tsx
+++ b/src/components/tables/OrdersTable.tsx
@@ -1,10 +1,72 @@
 "use client";
 
-import ConfigurableTable from "@/components/tables/ConfigurableTable";
-import { orderTableConfig, orders } from "@/data/dummyTableData";
+import { useCallback, useMemo } from "react";
 
-const OrdersTable = () => {
-  return <ConfigurableTable data={orders} config={orderTableConfig} />;
+import ConfigurableTable, { TableConfig } from "@/components/tables/ConfigurableTable";
+import type { Game } from "@/lib/games";
+
+interface OrdersTableProps {
+  data: Game[];
+}
+
+const OrdersTable = ({ data }: OrdersTableProps) => {
+  const handleEditGame = useCallback((game: Game) => {
+    console.log(`Edit game ${game.id}`);
+  }, []);
+
+  const handleRemoveGame = useCallback((game: Game) => {
+    console.log(`Remove game ${game.id}`);
+  }, []);
+
+  const tableConfig = useMemo<TableConfig<Game>>(
+    () => ({
+      name: "Games",
+      enablePagination: true,
+      enableSearch: true,
+      enableSorting: true,
+      defaultItemsPerPage: 10,
+      itemsPerPageOptions: [5, 10, 20],
+      getRowKey: (row) => row.id,
+      actions: {
+        align: "end",
+        edit: {
+          label: "Edit",
+          onClick: handleEditGame,
+        },
+        remove: {
+          label: "Remove",
+          onClick: handleRemoveGame,
+          buttonProps: {
+            className: "text-red-500",
+          },
+        },
+      },
+      fields: [
+        {
+          key: "id",
+          label: "ID",
+          dataKey: "id",
+          sortable: true,
+          searchAccessor: (row) => row.id,
+        },
+        {
+          key: "key",
+          label: "Key",
+          dataKey: "key",
+          sortable: true,
+        },
+        {
+          key: "name",
+          label: "Name",
+          dataKey: "name",
+          sortable: true,
+        },
+      ],
+    }),
+    [handleEditGame, handleRemoveGame]
+  );
+
+  return <ConfigurableTable data={data} config={tableConfig} />;
 };
 
 export default OrdersTable;

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,62 @@
+const DEFAULT_API_BASE_URL = "http://builder-web.192.168.49.2.nip.io";
+
+const ensureTrailingSlash = (value: string) => (value.endsWith("/") ? value : `${value}/`);
+const removeLeadingSlash = (value: string) => value.replace(/^\/+/, "");
+
+const resolveBaseUrl = () => {
+  const envBaseUrl =
+    typeof window === "undefined"
+      ? process.env.NEXT_PUBLIC_API_BASE_URL ?? process.env.API_BASE_URL
+      : process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  const sanitized = envBaseUrl?.trim();
+  if (sanitized && sanitized.length > 0) {
+    return sanitized;
+  }
+
+  return DEFAULT_API_BASE_URL;
+};
+
+const buildRequestUrl = (endpoint: string) => {
+  if (!endpoint) {
+    throw new Error("API endpoint is required");
+  }
+
+  if (/^https?:\/\//i.test(endpoint)) {
+    return endpoint;
+  }
+
+  const baseUrl = resolveBaseUrl();
+  const normalizedBase = ensureTrailingSlash(baseUrl.replace(/\/+$/, "/"));
+  const normalizedEndpoint = removeLeadingSlash(endpoint);
+
+  return `${normalizedBase}${normalizedEndpoint}`;
+};
+
+export class ApiError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export const fetchJson = async <TResponse>(
+  endpoint: string,
+  init?: RequestInit
+): Promise<TResponse> => {
+  const url = buildRequestUrl(endpoint);
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    const errorMessage = `Request to ${url} failed with status ${response.status}`;
+    throw new ApiError(response.status, errorMessage);
+  }
+
+  if (response.status === 204) {
+    return undefined as TResponse;
+  }
+
+  return (await response.json()) as TResponse;
+};
+
+export default fetchJson;

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -1,0 +1,24 @@
+import { fetchJson } from "@/lib/apiClient";
+
+export interface Game {
+  id: number;
+  key: string;
+  name: string;
+}
+
+type GamesApiResponse = Game[] | { data?: Game[] };
+
+const normalizeGamesResponse = (response: GamesApiResponse): Game[] => {
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  return response.data ?? [];
+};
+
+export const fetchGames = async (): Promise<Game[]> => {
+  const response = await fetchJson<GamesApiResponse>("/v1/games", { cache: "no-store" });
+  return normalizeGamesResponse(response);
+};
+
+export default fetchGames;


### PR DESCRIPTION
## Summary
- add a reusable API client that reads the configurable base URL and expose a games fetch helper
- load games on the admin games page and pass the data into the configurable table
- refresh the orders table configuration for games data and document the new environment variable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb2d78382483328eeb152c991f5eee