### PR TITLE
Add toast notifications for API errors

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 
 import { SidebarProvider } from '@/context/SidebarContext';
 import { ThemeProvider } from '@/context/ThemeContext';
+import { ToastProvider } from '@/components/ui/toast';
 
 const outfit = Outfit({
   subsets: ["latin"],
@@ -17,7 +18,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${outfit.className} dark:bg-gray-900`}>
         <ThemeProvider>
-          <SidebarProvider>{children}</SidebarProvider>
+          <SidebarProvider>
+            <ToastProvider>{children}</ToastProvider>
+          </SidebarProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/ui/toast/Toast.tsx
+++ b/src/components/ui/toast/Toast.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { FC } from "react";
+
+import Alert from "../alert/Alert";
+import { hideToast, ToastItem } from "@/lib/toastStore";
+
+interface ToastProps {
+  toast: ToastItem;
+}
+
+const Toast: FC<ToastProps> = ({ toast }) => {
+  const { id, variant, title, message, hideButtonLabel } = toast;
+  const label = hideButtonLabel ?? "Hide";
+
+  return (
+    <div className="space-y-2">
+      <Alert variant={variant} title={title} message={message} />
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => hideToast(id)}
+          className="rounded-lg px-3 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+          aria-label="Hide notification"
+        >
+          {label}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/ui/toast/ToastProvider.tsx
+++ b/src/components/ui/toast/ToastProvider.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import type { FC, PropsWithChildren } from "react";
+
+import Toast from "./Toast";
+import {
+  getServerToastsSnapshot,
+  getToastsSnapshot,
+  subscribeToToasts,
+  ToastItem,
+} from "@/lib/toastStore";
+
+const useToasts = (): ToastItem[] =>
+  useSyncExternalStore(subscribeToToasts, getToastsSnapshot, getServerToastsSnapshot);
+
+const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
+  const toasts = useToasts();
+
+  return (
+    <>
+      {children}
+
+      <div className="pointer-events-none fixed inset-x-0 top-4 z-[9999] flex justify-center px-4 sm:justify-end sm:px-6">
+        <div className="flex w-full max-w-sm flex-col gap-4">
+          {toasts.map((toast) => (
+            <div key={toast.id} className="pointer-events-auto">
+              <Toast toast={toast} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ToastProvider;

--- a/src/components/ui/toast/index.ts
+++ b/src/components/ui/toast/index.ts
@@ -1,0 +1,3 @@
+export { default as ToastProvider } from "./ToastProvider";
+export { showToast, hideToast } from "@/lib/toastStore";
+export type { ToastOptions, ToastVariant } from "@/lib/toastStore";

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,15 @@
+import { showToast } from "@/lib/toastStore";
+
 const DEFAULT_API_BASE_URL = "http://builder-web.192.168.49.2.nip.io";
+
+const showErrorToast = (message: string) => {
+  showToast({
+    variant: "error",
+    title: "Request failed",
+    message,
+    hideButtonLabel: "Dismiss",
+  });
+};
 
 const ensureTrailingSlash = (value: string) => (value.endsWith("/") ? value : `${value}/`);
 const removeLeadingSlash = (value: string) => value.replace(/^\/+/, "");
@@ -98,7 +109,9 @@ export const fetchJson = async <TResponse>(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unexpected error occurred";
-    throw new ApiError(0, `Request to ${url} failed: ${message}`);
+    const errorMessage = `Request to ${url} failed: ${message}`;
+    showErrorToast(errorMessage);
+    throw new ApiError(0, errorMessage);
   }
 
   if (!response.ok) {
@@ -106,6 +119,7 @@ export const fetchJson = async <TResponse>(
     const errorMessage =
       `Request to ${url} failed with status ${response.status}` +
       (details ? ` - ${details}` : "");
+    showErrorToast(errorMessage);
     throw new ApiError(response.status, errorMessage);
   }
 
@@ -117,10 +131,9 @@ export const fetchJson = async <TResponse>(
     return (await response.json()) as TResponse;
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    throw new ApiError(
-      response.status,
-      `Failed to parse JSON response from ${url}: ${reason}`
-    );
+    const errorMessage = `Failed to parse JSON response from ${url}: ${reason}`;
+    showErrorToast(errorMessage);
+    throw new ApiError(response.status, errorMessage);
   }
 };
 

--- a/src/lib/toastStore.ts
+++ b/src/lib/toastStore.ts
@@ -1,0 +1,87 @@
+export type ToastVariant = "success" | "error" | "warning" | "info";
+
+export interface ToastOptions {
+  id?: string;
+  variant: ToastVariant;
+  title: string;
+  message: string;
+  hideButtonLabel?: string;
+  duration?: number;
+}
+
+export interface ToastItem extends ToastOptions {
+  id: string;
+  createdAt: number;
+}
+
+type ToastListener = (toasts: ToastItem[]) => void;
+
+let toasts: ToastItem[] = [];
+const listeners = new Set<ToastListener>();
+
+const notify = () => {
+  for (const listener of listeners) {
+    listener([...toasts]);
+  }
+};
+
+export const subscribeToToasts = (listener: ToastListener) => {
+  listeners.add(listener);
+  listener([...toasts]);
+
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getToastsSnapshot = () => [...toasts];
+export const getServerToastsSnapshot = (): ToastItem[] => [];
+
+const shouldRenderToasts = () => typeof window !== "undefined";
+
+export const hideToast = (id: string) => {
+  const nextToasts = toasts.filter((toast) => toast.id !== id);
+  if (nextToasts.length === toasts.length) {
+    return;
+  }
+
+  toasts = nextToasts;
+  if (shouldRenderToasts()) {
+    notify();
+  }
+};
+
+export const showToast = (options: ToastOptions): string | undefined => {
+  if (!shouldRenderToasts()) {
+    return undefined;
+  }
+
+  const id = options.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const toast: ToastItem = {
+    ...options,
+    id,
+    createdAt: Date.now(),
+  };
+
+  toasts = [...toasts, toast];
+  notify();
+
+  if (options.duration && options.duration > 0) {
+    window.setTimeout(() => hideToast(id), options.duration);
+  }
+
+  return id;
+};
+
+export const clearToasts = () => {
+  if (!shouldRenderToasts()) {
+    return;
+  }
+
+  if (toasts.length === 0) {
+    return;
+  }
+
+  toasts = [];
+  notify();
+};


### PR DESCRIPTION
## Summary
- add a toast store and provider that render alert-styled notifications with a configurable hide button
- show error toasts from the shared API client when requests fail so the UI can continue functioning
- wrap the application layout with the toast provider to surface notifications globally

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb34d783a88332b90d5e66df8f605e