### PR TITLE
Fix toast server snapshot reference

### DIFF
--- a/src/lib/toastStore.ts
+++ b/src/lib/toastStore.ts
@@ -35,7 +35,9 @@ export const subscribeToToasts = (listener: ToastListener) => {
 };
 
 export const getToastsSnapshot = () => [...toasts];
-export const getServerToastsSnapshot = (): ToastItem[] => [];
+
+const serverToastsSnapshot: ToastItem[] = [];
+export const getServerToastsSnapshot = (): ToastItem[] => serverToastsSnapshot;
 
 const shouldRenderToasts = () => typeof window !== "undefined";
 


### PR DESCRIPTION
## Summary
- cache the server toast snapshot to provide a stable reference for `useSyncExternalStore`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3a1f642c8332bf4216ecb7241a59