### PR TITLE
Fix toast snapshot caching

### DIFF
--- a/src/lib/toastStore.ts
+++ b/src/lib/toastStore.ts
@@ -34,7 +34,7 @@ export const subscribeToToasts = (listener: ToastListener) => {
   };
 };
 
-export const getToastsSnapshot = () => [...toasts];
+export const getToastsSnapshot = () => toasts;
 
 const serverToastsSnapshot: ToastItem[] = [];
 export const getServerToastsSnapshot = (): ToastItem[] => serverToastsSnapshot;


### PR DESCRIPTION
## Summary
- return the existing toast store snapshot instead of cloning to keep useSyncExternalStore stable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3c0449288332b70d7b929f3dd27b