### PR TITLE
Normalize games API response

### DIFF
--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -4,16 +4,40 @@ export interface Game {
   id: number;
   key: string;
   name: string;
+  studioId?: number;
 }
 
-type GamesApiResponse = Game[] | { data?: Game[] };
+type GamesApiResponse =
+  | Game[]
+  | { data?: Game[] }
+  | {
+      content?: {
+        id: number;
+        gameId: string;
+        name: string;
+        studioId: number;
+      }[];
+    };
 
 const normalizeGamesResponse = (response: GamesApiResponse): Game[] => {
   if (Array.isArray(response)) {
     return response;
   }
 
-  return response.data ?? [];
+  if ("content" in response && Array.isArray(response.content)) {
+    return response.content.map(({ id, gameId, name, studioId }) => ({
+      id,
+      key: gameId,
+      name,
+      studioId,
+    }));
+  }
+
+  if ("data" in response && Array.isArray(response.data)) {
+    return response.data;
+  }
+
+  return [];
 };
 
 export const fetchGames = async (): Promise<Game[]> => {


### PR DESCRIPTION
## Summary
- add support for the paged games response shape returned by the API
- map gameId to the table key and expose the studio identifier
- keep backwards compatibility with previous array-based responses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3e18e804833284abfe9079df0e0f