### PR TITLE
Add ComponentCard action slot and new plugin button

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import ComponentCard from "@/components/common/ComponentCard";
 import PluginsTable from "@/components/tables/PluginsTable";
 import fetchPlugins from "@/lib/plugins/fetchPlugins";
+import Link from "next/link";
 
 export const metadata: Metadata = {
     title: "FiG | All plugins",
@@ -16,7 +17,17 @@ export default async function PluginsPage() {
         <div>
             <PageBreadcrumb pageTitle="All plugins" />
             <div className="space-y-6">
-                <ComponentCard title="Plugins">
+                <ComponentCard
+                    title="Plugins"
+                    action={
+                        <Link
+                            href="/builder/plugins/new"
+                            className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white shadow-theme-xs transition-colors hover:bg-brand-600"
+                        >
+                            New Plugin
+                        </Link>
+                    }
+                >
                     <PluginsTable data={games} />
                 </ComponentCard>
             </div>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,19 +1,20 @@
-'use client' // Error boundaries must be Client Components
+"use client"; // Error boundaries must be Client Components
 
-export default function GlobalError({
-                                        error,
-                                        reset,
-                                    }: {
-    error: Error & { digest?: string }
-    reset: () => void
-}) {
-    return (
-        // global-error must include html and body tags
-        <html>
-        <body>
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  console.error(error);
+
+  return (
+    // global-error must include html and body tags
+    <html>
+      <body>
         <h2>Something went wrong!</h2>
         <button onClick={() => reset()}>Try again</button>
-        </body>
-        </html>
-    )
+      </body>
+    </html>
+  );
 }

--- a/src/components/common/ComponentCard.tsx
+++ b/src/components/common/ComponentCard.tsx
@@ -5,6 +5,7 @@ interface ComponentCardProps {
   children: React.ReactNode;
   className?: string; // Additional custom classes for styling
   desc?: string; // Description text
+  action?: React.ReactNode; // Optional action element rendered next to the title
 }
 
 const ComponentCard: React.FC<ComponentCardProps> = ({
@@ -12,6 +13,7 @@ const ComponentCard: React.FC<ComponentCardProps> = ({
   children,
   className = "",
   desc = "",
+  action,
 }) => {
   return (
     <div
@@ -19,14 +21,19 @@ const ComponentCard: React.FC<ComponentCardProps> = ({
     >
       {/* Card Header */}
       <div className="px-6 py-5">
-        <h3 className="text-base font-medium text-gray-800 dark:text-white/90">
-          {title}
-        </h3>
-        {desc && (
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            {desc}
-          </p>
-        )}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-base font-medium text-gray-800 dark:text-white/90">
+              {title}
+            </h3>
+            {desc && (
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {desc}
+              </p>
+            )}
+          </div>
+          {action && <div className="shrink-0">{action}</div>}
+        </div>
       </div>
 
       {/* Card Body */}


### PR DESCRIPTION
## Summary
- add an optional action slot to ComponentCard for rendering header controls
- style the card header to accommodate the new action content without affecting the description
- surface a "New Plugin" link on the plugins page that routes to the creation flow
- tidy the global error boundary and log captured errors to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdc36786fc8332ab5987d1f2753e34