### PR TITLE
Fix sidebar submenu activation for nested routes

### DIFF
--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -255,7 +255,20 @@ const AppSidebar: React.FC = () => {
     const subMenuRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
     // const isActive = (path: string) => path === pathname;
-    const isActive = useCallback((path: string) => path === pathname, [pathname]);
+    const isActive = useCallback(
+        (path: string) => {
+            if (!pathname) {
+                return false;
+            }
+
+            if (path === "/") {
+                return pathname === "/";
+            }
+
+            return pathname === path || pathname.startsWith(`${path}/`);
+        },
+        [pathname],
+    );
 
     useEffect(() => {
         // Check if the current path matches any submenu item


### PR DESCRIPTION
## Summary
- update AppSidebar active route detection so nested routes keep their parent submenu open
- ensure root path only matches the homepage while other paths match exact and nested routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdca7878f48332922fd1c0d60508a1