### PR TITLE
feat: extend breadcrumbs for plugins pages

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/error.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/error.tsx
@@ -19,7 +19,13 @@ export default function Error({
     return (
 
         <div>
-            <PageBreadcrumb pageTitle="All Games" />
+            <PageBreadcrumb
+                pageTitle="All plugins"
+                breadcrumbs={[
+                    { label: "Builder", href: "/builder" },
+                    { label: "Plugins" },
+                ]}
+            />
             <div className="space-y-6">
                 <ComponentCard title="Games">
                     <Alert

--- a/src/app/(admin)/(builder)/builder/plugins/new/error.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/new/error.tsx
@@ -19,7 +19,14 @@ export default function Error({
     return (
 
         <div>
-            <PageBreadcrumb pageTitle="All Games" />
+            <PageBreadcrumb
+                pageTitle="New plugin"
+                breadcrumbs={[
+                    { label: "Builder", href: "/builder" },
+                    { label: "Plugins", href: "/builder/plugins" },
+                    { label: "New plugin" },
+                ]}
+            />
             <div className="space-y-6">
                 <ComponentCard title="Games">
                     <Alert

--- a/src/app/(admin)/(builder)/builder/plugins/new/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/new/page.tsx
@@ -11,7 +11,14 @@ export default async function NewPluginPage() {
 
     return (
         <div>
-            <PageBreadcrumb pageTitle="New plugin" />
+            <PageBreadcrumb
+                pageTitle="New plugin"
+                breadcrumbs={[
+                    { label: "Builder", href: "/builder" },
+                    { label: "Plugins", href: "/builder/plugins" },
+                    { label: "New plugin" },
+                ]}
+            />
             <div className="space-y-6">
                 <ComponentCard title="Plugins">
                     <div>Content</div>

--- a/src/app/(admin)/(builder)/builder/plugins/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/page.tsx
@@ -15,7 +15,13 @@ export default async function PluginsPage() {
 
     return (
         <div>
-            <PageBreadcrumb pageTitle="All plugins" />
+            <PageBreadcrumb
+                pageTitle="All plugins"
+                breadcrumbs={[
+                    { label: "Builder", href: "/builder" },
+                    { label: "Plugins" },
+                ]}
+            />
             <div className="space-y-6">
                 <ComponentCard
                     title="Plugins"

--- a/src/components/common/PageBreadCrumb.tsx
+++ b/src/components/common/PageBreadCrumb.tsx
@@ -1,11 +1,27 @@
 import Link from "next/link";
 import React from "react";
 
-interface BreadcrumbProps {
-  pageTitle: string;
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
 }
 
-const PageBreadcrumb: React.FC<BreadcrumbProps> = ({ pageTitle }) => {
+interface BreadcrumbProps {
+  pageTitle: string;
+  breadcrumbs?: BreadcrumbItem[];
+}
+
+const PageBreadcrumb: React.FC<BreadcrumbProps> = ({ pageTitle, breadcrumbs }) => {
+  const breadcrumbItems: BreadcrumbItem[] = React.useMemo(() => {
+    const items = breadcrumbs ? [...breadcrumbs] : [];
+
+    if (pageTitle && (!items.length || items[items.length - 1]?.label !== pageTitle)) {
+      items.push({ label: pageTitle });
+    }
+
+    return items;
+  }, [breadcrumbs, pageTitle]);
+
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
       <h2
@@ -22,27 +38,42 @@ const PageBreadcrumb: React.FC<BreadcrumbProps> = ({ pageTitle }) => {
               href="/"
             >
               Home
-              <svg
-                className="stroke-current"
-                width="17"
-                height="16"
-                viewBox="0 0 17 16"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6.0765 12.667L10.2432 8.50033L6.0765 4.33366"
-                  stroke=""
-                  strokeWidth="1.2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
             </Link>
           </li>
-          <li className="text-sm text-gray-800 dark:text-white/90">
-            {pageTitle}
-          </li>
+          {breadcrumbItems.map((item, index) => {
+            const isLast = index === breadcrumbItems.length - 1;
+            const textClass = isLast
+              ? "text-gray-800 dark:text-white/90"
+              : "text-gray-500 dark:text-gray-400";
+
+            return (
+              <li key={`${item.label}-${index}`} className="inline-flex items-center gap-1.5 text-sm">
+                <svg
+                  className="stroke-current"
+                  width="17"
+                  height="16"
+                  viewBox="0 0 17 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M6.0765 12.667L10.2432 8.50033L6.0765 4.33366"
+                    stroke=""
+                    strokeWidth="1.2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                {item.href ? (
+                  <Link className={textClass} href={item.href}>
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span className={textClass}>{item.label}</span>
+                )}
+              </li>
+            );
+          })}
         </ol>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- allow PageBreadcrumb to accept optional breadcrumb arrays and append the page title when needed
- update builder plugin pages to provide breadcrumb sequences for listings, creation, and error boundaries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdce8ff2a08332993a3acf04461918