### PR TITLE
Allow TableCell to accept style prop

### DIFF
--- a/src/components/ui/table/index.tsx
+++ b/src/components/ui/table/index.tsx
@@ -31,6 +31,7 @@ interface TableCellProps {
   className?: string; // Optional className for styling
   colSpan?: number; // Optional colspan support for table cells
   onClick?: React.MouseEventHandler<HTMLTableCellElement>; // Optional click handler
+  style?: React.CSSProperties; // Optional inline styles for table cells
 }
 
 // Table Component
@@ -60,17 +61,28 @@ const TableCell: React.FC<TableCellProps> = ({
   className,
   colSpan,
   onClick,
+  style,
 }) => {
   if (isHeader) {
     return (
-      <th className={` ${className}`} colSpan={colSpan} onClick={onClick}>
+      <th
+        className={` ${className}`}
+        colSpan={colSpan}
+        onClick={onClick}
+        style={style}
+      >
         {children}
       </th>
     );
   }
 
   return (
-    <td className={` ${className}`} colSpan={colSpan} onClick={onClick}>
+    <td
+      className={` ${className}`}
+      colSpan={colSpan}
+      onClick={onClick}
+      style={style}
+    >
       {children}
     </td>
   );


### PR DESCRIPTION
## Summary
- add an optional `style` prop to the shared `TableCell` component
- pass inline styles through to rendered `<th>` and `<td>` elements to support width overrides

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd880145c8332bf604575b6a2078b