### PR TITLE
Add new plugin form page and enhance form components

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/new/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/new/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from "next";
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
 import ComponentCard from "@/components/common/ComponentCard";
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import TextArea from "@/components/form/input/TextArea";
+import Button from "@/components/ui/button/Button";
 
 export const metadata: Metadata = {
     title: "FiG | New plugin",
@@ -21,7 +25,57 @@ export default async function NewPluginPage() {
             />
             <div className="space-y-6">
                 <ComponentCard title="Plugins">
-                    <div>Content</div>
+                    <form className="space-y-6">
+                        <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="name">
+                                    Name<span className="text-error-500">*</span>
+                                </Label>
+                                <Input
+                                    id="name"
+                                    name="name"
+                                    placeholder="Enter plugin name"
+                                    required
+                                />
+                            </div>
+                            <div>
+                                <Label htmlFor="pluginKey">
+                                    Plugin key<span className="text-error-500">*</span>
+                                </Label>
+                                <Input
+                                    id="pluginKey"
+                                    name="pluginKey"
+                                    placeholder="Enter plugin key"
+                                    required
+                                />
+                            </div>
+                        </div>
+                        <div>
+                            <Label htmlFor="version">
+                                Version<span className="text-error-500">*</span>
+                            </Label>
+                            <Input
+                                id="version"
+                                name="version"
+                                placeholder="Enter plugin version"
+                                required
+                            />
+                        </div>
+                        <div>
+                            <Label htmlFor="configuration">Configuration</Label>
+                            <TextArea
+                                id="configuration"
+                                name="configuration"
+                                placeholder="Add plugin configuration"
+                                rows={4}
+                            />
+                        </div>
+                        <div className="flex justify-end">
+                            <Button type="submit" className="min-w-32 justify-center">
+                                Create plugin
+                            </Button>
+                        </div>
+                    </form>
                 </ComponentCard>
             </div>
         </div>

--- a/src/components/form/input/InputField.tsx
+++ b/src/components/form/input/InputField.tsx
@@ -15,6 +15,7 @@ interface InputProps {
   success?: boolean;
   error?: boolean;
   hint?: string; // Optional hint text
+  required?: boolean;
 }
 
 const Input: FC<InputProps> = ({
@@ -32,6 +33,7 @@ const Input: FC<InputProps> = ({
   success = false,
   error = false,
   hint,
+  required = false,
 }) => {
   // Determine input styles based on state (disabled, success, error)
   let inputClasses = `h-11 w-full rounded-lg border appearance-none px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:outline-hidden focus:ring-3 dark:bg-gray-900 dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800 ${className}`;
@@ -60,6 +62,7 @@ const Input: FC<InputProps> = ({
         max={max}
         step={step}
         disabled={disabled}
+        required={required}
         className={inputClasses}
       />
 

--- a/src/components/form/input/TextArea.tsx
+++ b/src/components/form/input/TextArea.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 interface TextareaProps {
+  id?: string;
+  name?: string;
   placeholder?: string; // Placeholder text
   rows?: number; // Number of rows
   value?: string; // Current value
@@ -12,6 +14,8 @@ interface TextareaProps {
 }
 
 const TextArea: React.FC<TextareaProps> = ({
+  id,
+  name,
   placeholder = "Enter your message", // Default placeholder
   rows = 3, // Default number of rows
   value = "", // Default value
@@ -40,6 +44,8 @@ const TextArea: React.FC<TextareaProps> = ({
   return (
     <div className="relative">
       <textarea
+        id={id}
+        name={name}
         placeholder={placeholder}
         rows={rows}
         value={value}

--- a/src/components/ui/button/Button.tsx
+++ b/src/components/ui/button/Button.tsx
@@ -9,6 +9,7 @@ interface ButtonProps {
   onClick?: () => void; // Click handler
   disabled?: boolean; // Disabled state
   className?: string; // Disabled state
+  type?: "button" | "submit" | "reset";
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -20,6 +21,7 @@ const Button: React.FC<ButtonProps> = ({
   onClick,
   className = "",
   disabled = false,
+  type = "submit",
 }) => {
   // Size Classes
   const sizeClasses = {
@@ -44,6 +46,7 @@ const Button: React.FC<ButtonProps> = ({
       }`}
       onClick={onClick}
       disabled={disabled}
+      type={type}
     >
       {startIcon && <span className="flex items-center">{startIcon}</span>}
       {children}


### PR DESCRIPTION
## Summary
- add a builder plugin creation form with required name, key, version, and optional configuration textarea
- extend shared input and textarea components with required, id, and name support for better form accessibility
- allow the shared button component to accept an explicit button type for form submissions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cde41454a08332b165a66963ab06b2