### PR TITLE
Fix textarea as client component

### DIFF
--- a/src/components/form/input/TextArea.tsx
+++ b/src/components/form/input/TextArea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 
 interface TextareaProps {


### PR DESCRIPTION
## Summary
- mark the shared textarea component as a client component so it can accept event handlers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cde58e66288332984954c6ff79fcb0