### PR TITLE
Fix textarea configuration field

### DIFF
--- a/src/components/form/input/TextArea.tsx
+++ b/src/components/form/input/TextArea.tsx
@@ -20,7 +20,7 @@ const TextArea: React.FC<TextareaProps> = ({
   name,
   placeholder = "Enter your message", // Default placeholder
   rows = 3, // Default number of rows
-  value = "", // Default value
+  value, // Current value
   onChange, // Callback for changes
   className = "", // Additional custom styles
   disabled = false, // Disabled state
@@ -50,10 +50,10 @@ const TextArea: React.FC<TextareaProps> = ({
         name={name}
         placeholder={placeholder}
         rows={rows}
-        value={value}
         onChange={handleChange}
         disabled={disabled}
         className={textareaClasses}
+        {...(value !== undefined ? { value } : {})}
       />
       {hint && (
         <p


### PR DESCRIPTION
## Summary
- make the shared TextArea component uncontrolled by default
- ensure the configuration field on the new plugin page accepts typing when no value is provided

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cde7f8f79c8332a0acb98ca2f2d63b