### PR TITLE
Add create plugin request and form submission

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/new/NewPluginForm.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/new/NewPluginForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import TextArea from "@/components/form/input/TextArea";
+import Button from "@/components/ui/button/Button";
+import { createPlugin } from "@/lib/plugins/createPlugin";
+import { showToast } from "@/lib/toastStore";
+
+const NewPluginForm = () => {
+    const router = useRouter();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isSubmitting) {
+            return;
+        }
+
+        const form = event.currentTarget;
+        const formData = new FormData(form);
+
+        const name = String(formData.get("name") ?? "").trim();
+        const pluginKey = String(formData.get("pluginKey") ?? "").trim();
+        const version = String(formData.get("version") ?? "").trim();
+        const configurationValue = formData.get("configuration");
+        const configuration =
+            configurationValue !== null ? String(configurationValue).trim() : undefined;
+
+        setIsSubmitting(true);
+
+        try {
+            await createPlugin({
+                name,
+                pluginKey,
+                version,
+                configuration: configuration?.length ? configuration : undefined,
+            });
+
+            showToast({
+                variant: "success",
+                title: "Plugin created",
+                message: `${name} has been created successfully.`,
+                hideButtonLabel: "Dismiss",
+            });
+
+            router.push("/builder/plugins");
+        } catch (error) {
+            // Errors are handled by the API client, so we just log for debugging purposes.
+            console.error("Failed to create plugin", error);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+            <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+                <div>
+                    <Label htmlFor="name">
+                        Name<span className="text-error-500">*</span>
+                    </Label>
+                    <Input id="name" name="name" placeholder="Enter plugin name" required />
+                </div>
+                <div>
+                    <Label htmlFor="pluginKey">
+                        Plugin key<span className="text-error-500">*</span>
+                    </Label>
+                    <Input
+                        id="pluginKey"
+                        name="pluginKey"
+                        placeholder="Enter plugin key"
+                        required
+                    />
+                </div>
+            </div>
+            <div>
+                <Label htmlFor="version">
+                    Version<span className="text-error-500">*</span>
+                </Label>
+                <Input
+                    id="version"
+                    name="version"
+                    placeholder="Enter plugin version"
+                    required
+                />
+            </div>
+            <div>
+                <Label htmlFor="configuration">Configuration</Label>
+                <TextArea
+                    id="configuration"
+                    name="configuration"
+                    placeholder="Add plugin configuration"
+                    rows={4}
+                />
+            </div>
+            <div className="flex justify-end">
+                <Button
+                    type="submit"
+                    className="min-w-32 justify-center"
+                    disabled={isSubmitting}
+                >
+                    {isSubmitting ? "Creating..." : "Create plugin"}
+                </Button>
+            </div>
+        </form>
+    );
+};
+
+export default NewPluginForm;

--- a/src/app/(admin)/(builder)/builder/plugins/new/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/new/page.tsx
@@ -1,10 +1,7 @@
 import { Metadata } from "next";
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
 import ComponentCard from "@/components/common/ComponentCard";
-import Label from "@/components/form/Label";
-import Input from "@/components/form/input/InputField";
-import TextArea from "@/components/form/input/TextArea";
-import Button from "@/components/ui/button/Button";
+import NewPluginForm from "./NewPluginForm";
 
 export const metadata: Metadata = {
     title: "FiG | New plugin",
@@ -12,7 +9,6 @@ export const metadata: Metadata = {
 };
 
 export default async function NewPluginPage() {
-
     return (
         <div>
             <PageBreadcrumb
@@ -25,57 +21,7 @@ export default async function NewPluginPage() {
             />
             <div className="space-y-6">
                 <ComponentCard title="Plugins">
-                    <form className="space-y-6">
-                        <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
-                            <div>
-                                <Label htmlFor="name">
-                                    Name<span className="text-error-500">*</span>
-                                </Label>
-                                <Input
-                                    id="name"
-                                    name="name"
-                                    placeholder="Enter plugin name"
-                                    required
-                                />
-                            </div>
-                            <div>
-                                <Label htmlFor="pluginKey">
-                                    Plugin key<span className="text-error-500">*</span>
-                                </Label>
-                                <Input
-                                    id="pluginKey"
-                                    name="pluginKey"
-                                    placeholder="Enter plugin key"
-                                    required
-                                />
-                            </div>
-                        </div>
-                        <div>
-                            <Label htmlFor="version">
-                                Version<span className="text-error-500">*</span>
-                            </Label>
-                            <Input
-                                id="version"
-                                name="version"
-                                placeholder="Enter plugin version"
-                                required
-                            />
-                        </div>
-                        <div>
-                            <Label htmlFor="configuration">Configuration</Label>
-                            <TextArea
-                                id="configuration"
-                                name="configuration"
-                                placeholder="Add plugin configuration"
-                                rows={4}
-                            />
-                        </div>
-                        <div className="flex justify-end">
-                            <Button type="submit" className="min-w-32 justify-center">
-                                Create plugin
-                            </Button>
-                        </div>
-                    </form>
+                    <NewPluginForm />
                 </ComponentCard>
             </div>
         </div>

--- a/src/lib/plugins/createPlugin.ts
+++ b/src/lib/plugins/createPlugin.ts
@@ -1,0 +1,22 @@
+import { fetchData } from "@/lib/apiClient";
+import { Plugin } from "@/lib/plugins/pluginType";
+
+export interface CreatePluginPayload {
+    name: string;
+    pluginKey: string;
+    version: string;
+    configuration?: string;
+}
+
+export const createPlugin = async (payload: CreatePluginPayload): Promise<Plugin> => {
+    return fetchData<Plugin>("/v1/plugins", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            accept: "*/*",
+        },
+        body: JSON.stringify(payload),
+    });
+};
+
+export default createPlugin;


### PR DESCRIPTION
## Summary
- add a reusable createPlugin client that posts to /v1/plugins using the shared API client
- convert the new plugin page to render a client form that submits via the new request
- show a success toast and redirect back to the plugins list after the plugin is created

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cde9a8e7e083329a4cbf7cc36fd8ab