### PR TITLE
Update new plugin form to capture full metadata

### DIFF
--- a/src/lib/plugins/createPlugin.ts
+++ b/src/lib/plugins/createPlugin.ts
@@ -4,7 +4,11 @@ import { Plugin } from "@/lib/plugins/pluginType";
 export interface CreatePluginPayload {
     name: string;
     pluginKey: string;
+    groupId?: string;
+    artifactId?: string;
     version: string;
+    description?: string;
+    changeLog?: string;
     configuration?: string;
 }
 


### PR DESCRIPTION
## Summary
- expand the builder new plugin form to collect full plugin metadata and surface validation errors
- allow the createPlugin client to forward additional metadata fields

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d06b7c9ff883328f1ae6e019fc095a