### PR TITLE
Enhance plugin detail and version management

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/page.tsx
@@ -1,12 +1,15 @@
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+import ComponentCard from "@/components/common/ComponentCard";
+import PluginVersionsTable from "@/components/tables/PluginVersionsTable";
+import { ApiError } from "@/lib/apiClient";
+import fetchPluginById from "@/lib/plugins/fetchPluginById";
 import { Metadata } from "next";
-import React from "react";
+import { notFound } from "next/navigation";
 
 export const metadata: Metadata = {
-    title: "Next.js Blank Page | TailAdmin - Next.js Dashboard Template",
-    description: "This is Next.js Blank Page TailAdmin Dashboard Template",
+    title: "FiG | Plugin details",
+    description: "Plugin details page",
 };
-
 
 interface PluginPageProps {
     params: {
@@ -14,25 +17,60 @@ interface PluginPageProps {
     };
 }
 
-export default function PluginPage({params}: PluginPageProps) {
+export default async function PluginPage({params}: PluginPageProps) {
+    const { pluginId } = params;
 
-    const pluginId = params.pluginId;
+    try {
+        const plugin = await fetchPluginById(pluginId);
 
-    return (
-        <div>
-            <PageBreadcrumb pageTitle={`Plugin ${pluginId}`}/>
-            <div
-                className="min-h-screen rounded-2xl border border-gray-200 bg-white px-5 py-7 dark:border-gray-800 dark:bg-white/[0.03] xl:px-10 xl:py-12">
-                <div className="mx-auto w-full max-w-[630px] text-center">
-                    <h3 className="mb-4 font-semibold text-gray-800 text-theme-xl dark:text-white/90 sm:text-2xl">
-                        Card Title Here
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 sm:text-base">
-                        Start putting content on grids or panels, you can also use different
-                        combinations of grids.Please check out the dashboard and other pages
-                    </p>
+        return (
+            <div>
+                <PageBreadcrumb
+                    pageTitle={`Plugin: ${plugin.name}`}
+                    breadcrumbs={[
+                        { label: "Builder" },
+                        { label: "Plugins", href: "/builder/plugins" },
+                        { label: plugin.name },
+                    ]}
+                />
+                <div className="space-y-6">
+                    <ComponentCard title="Plugin details">
+                        <div className="grid gap-6 md:grid-cols-2">
+                            <div>
+                                <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Plugin ID</p>
+                                <p className="mt-1 text-base font-semibold text-gray-800 dark:text-white/90">{plugin.id}</p>
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Plugin key</p>
+                                <p className="mt-1 text-base font-semibold text-gray-800 dark:text-white/90">{plugin.pluginKey}</p>
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Group ID</p>
+                                <p className="mt-1 text-base font-semibold text-gray-800 dark:text-white/90">{plugin.groupId || "—"}</p>
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Artifact ID</p>
+                                <p className="mt-1 text-base font-semibold text-gray-800 dark:text-white/90">{plugin.artifactId || "—"}</p>
+                            </div>
+                        </div>
+                        <div>
+                            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Description</p>
+                            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                                {plugin.description ? plugin.description : "No description provided."}
+                            </p>
+                        </div>
+                    </ComponentCard>
+                    <ComponentCard title="Versions">
+                        <PluginVersionsTable versions={plugin.versions} pluginId={plugin.id} />
+                    </ComponentCard>
                 </div>
             </div>
-        </div>
-    );
+        );
+    } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+            notFound();
+        }
+
+        throw error;
+    }
 }

--- a/src/components/tables/PluginVersionsTable.tsx
+++ b/src/components/tables/PluginVersionsTable.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { useMemo } from "react";
+import Link from "next/link";
+
+import ConfigurableTable, { TableConfig } from "@/components/tables/ConfigurableTable";
+import { PluginVersion } from "@/lib/plugins/pluginType";
+
+interface PluginVersionsTableProps {
+    versions: PluginVersion[];
+    pluginId: number | string;
+}
+
+const PluginVersionsTable = ({ versions, pluginId }: PluginVersionsTableProps) => {
+    const sanitizedPluginId = String(pluginId);
+
+    const tableConfig = useMemo<TableConfig<PluginVersion>>(
+        () => ({
+            name: "Plugin versions",
+            headerAction: (
+                <Link
+                    href={`/builder/plugins/${sanitizedPluginId}/versions/new`}
+                    className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white shadow-theme-xs transition-colors hover:bg-brand-600"
+                >
+                    New version
+                </Link>
+            ),
+            enablePagination: true,
+            enableSearch: false,
+            enableSorting: true,
+            defaultItemsPerPage: 5,
+            itemsPerPageOptions: [5, 10, 20],
+            getRowKey: (row) => row.id ?? row.version,
+            fields: [
+                {
+                    key: "id",
+                    label: "ID",
+                    dataKey: "id",
+                    sortable: true,
+                },
+                {
+                    key: "version",
+                    label: "Version",
+                    dataKey: "version",
+                    sortable: true,
+                },
+                {
+                    key: "changeLog",
+                    label: "Change log",
+                    dataKey: "changeLog",
+                    sortable: false,
+                    render: (row) => (row.changeLog?.trim().length ? row.changeLog : "—"),
+                },
+                {
+                    key: "configuration",
+                    label: "Configuration",
+                    dataKey: "configuration",
+                    sortable: false,
+                    render: (row) => (row.configuration?.trim().length ? row.configuration : "—"),
+                },
+            ],
+        }),
+        [sanitizedPluginId],
+    );
+
+    return <ConfigurableTable data={versions} config={tableConfig} />;
+};
+
+export default PluginVersionsTable;

--- a/src/components/tables/PluginsTable.tsx
+++ b/src/components/tables/PluginsTable.tsx
@@ -5,13 +5,15 @@ import React, { useCallback, useMemo } from "react";
 import ConfigurableTable, { TableConfig } from "@/components/tables/ConfigurableTable";
 import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
 import { Plugin } from "@/lib/plugins/pluginType";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 interface PluginsTableProps {
     data: Plugin[];
 }
 
 const PluginsTable = ({data}: PluginsTableProps) => {
+    const router = useRouter();
+
     const handleEditPlugin = useCallback((plugin: Plugin) => {
         console.log(`Edit plugin ${plugin.id}`);
     }, []);
@@ -19,6 +21,13 @@ const PluginsTable = ({data}: PluginsTableProps) => {
     const handleRemovePlugin = useCallback((plugin: Plugin) => {
         console.log(`Remove plugin ${plugin.id}`);
     }, []);
+
+    const handleNavigateToPlugin = useCallback(
+        (plugin: Plugin) => {
+            router.push(`/builder/plugins/${plugin.id}`);
+        },
+        [router],
+    );
 
     const tableConfig = useMemo<TableConfig<Plugin>>(
         () => ({
@@ -38,15 +47,9 @@ const PluginsTable = ({data}: PluginsTableProps) => {
                         <div
                             className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-white/[0.05] dark:bg-white/[0.03]">
                             <div
-                                className="flex items-center justify-between border-b border-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 dark:border-white/[0.05] dark:text-gray-200"
+                                className="border-b border-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 dark:border-white/[0.05] dark:text-gray-200"
                             >
                                 <span>Versions</span>
-                                <Link
-                                    href={`/builder/plugins/${row.id}/versions/new`}
-                                    className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white shadow-theme-xs transition-colors hover:bg-brand-600"
-                                >
-                                    New Version
-                                </Link>
                             </div>
                             <div className="max-w-full overflow-x-auto">
                                 <Table className="min-w-[600px]">
@@ -131,6 +134,7 @@ const PluginsTable = ({data}: PluginsTableProps) => {
                     },
                 },
             },
+            onRowClick: handleNavigateToPlugin,
             fields: [
                 {
                     key: "id",
@@ -170,7 +174,7 @@ const PluginsTable = ({data}: PluginsTableProps) => {
                 },
             ],
         }),
-        [handleEditPlugin, handleRemovePlugin]
+        [handleEditPlugin, handleNavigateToPlugin, handleRemovePlugin]
     );
 
     return <ConfigurableTable data={data} config={tableConfig} />;

--- a/src/components/ui/table/index.tsx
+++ b/src/components/ui/table/index.tsx
@@ -22,6 +22,7 @@ interface TableBodyProps {
 interface TableRowProps {
   children: ReactNode; // Cells (th or td)
   className?: string; // Optional className for styling
+  onClick?: React.MouseEventHandler<HTMLTableRowElement>; // Optional click handler for the row
 }
 
 // Props for TableCell
@@ -50,8 +51,12 @@ const TableBody: React.FC<TableBodyProps> = ({ children, className }) => {
 };
 
 // TableRow Component
-const TableRow: React.FC<TableRowProps> = ({ children, className }) => {
-  return <tr className={className}>{children}</tr>;
+const TableRow: React.FC<TableRowProps> = ({ children, className, onClick }) => {
+  return (
+    <tr className={className} onClick={onClick}>
+      {children}
+    </tr>
+  );
 };
 
 // TableCell Component

--- a/src/lib/plugins/createPluginVersion.ts
+++ b/src/lib/plugins/createPluginVersion.ts
@@ -1,0 +1,24 @@
+import { fetchData } from "@/lib/apiClient";
+import { PluginVersion } from "@/lib/plugins/pluginType";
+
+export interface CreatePluginVersionPayload {
+    version: string;
+    changeLog?: string;
+    configuration: string;
+}
+
+export const createPluginVersion = async (
+    pluginId: string | number,
+    payload: CreatePluginVersionPayload,
+): Promise<PluginVersion> => {
+    return fetchData<PluginVersion>(`/v1/plugins/${pluginId}/versions`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            accept: "*/*",
+        },
+        body: JSON.stringify(payload),
+    });
+};
+
+export default createPluginVersion;

--- a/src/lib/plugins/fetchPluginById.ts
+++ b/src/lib/plugins/fetchPluginById.ts
@@ -1,0 +1,54 @@
+import { fetchData } from "@/lib/apiClient";
+import { Plugin, PluginVersion } from "@/lib/plugins/pluginType";
+
+interface PluginResponseVersion {
+    id: number;
+    version: string;
+    changeLog?: string | null;
+    configuration?: string | null;
+}
+
+interface PluginResponse {
+    id: number;
+    name: string;
+    pluginKey: string;
+    groupId?: string | null;
+    artifactId?: string | null;
+    description?: string | null;
+    versions?: PluginResponseVersion[] | null;
+}
+
+const normalizeVersion = ({ id, version, changeLog, configuration }: PluginResponseVersion): PluginVersion => ({
+    id,
+    version,
+    changeLog: changeLog ?? "",
+    configuration: configuration ?? "",
+});
+
+const normalizePlugin = ({
+    id,
+    name,
+    pluginKey,
+    groupId,
+    artifactId,
+    description,
+    versions,
+}: PluginResponse): Plugin => ({
+    id,
+    name,
+    pluginKey,
+    groupId: groupId ?? "",
+    artifactId: artifactId ?? "",
+    description: description ?? "",
+    versions: versions?.map(normalizeVersion) ?? [],
+});
+
+export const fetchPluginById = async (pluginId: string | number): Promise<Plugin> => {
+    const response = await fetchData<PluginResponse>(`/v1/plugins/${pluginId}`, {
+        cache: "no-store",
+    });
+
+    return normalizePlugin(response);
+};
+
+export default fetchPluginById;


### PR DESCRIPTION
## Summary
- implement plugin detail view that loads plugin data, shows metadata, and lists existing versions with a call-to-action for new versions
- add client helpers and form updates to create plugin versions with validation and redirect to the plugin page
- extend shared table components to support header actions and row click navigation used by the plugins table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0723646c083329af98b2236f2023f