### PR TITLE
Fix plugin page params handling

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/page.tsx
@@ -12,13 +12,13 @@ export const metadata: Metadata = {
 };
 
 interface PluginPageProps {
-    params: {
+    params: Promise<{
         pluginId: string;
-    };
+    }>;
 }
 
 export default async function PluginPage({params}: PluginPageProps) {
-    const { pluginId } = params;
+    const { pluginId } = await params;
 
     try {
         const plugin = await fetchPluginById(pluginId);


### PR DESCRIPTION
## Summary
- await dynamic route params on the plugin page to satisfy Next.js requirement

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d075a2dbe48332973232c32463b135