### PR TITLE
Refactor plugin edit forms for updates

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/edit/EditPluginForm.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/edit/EditPluginForm.tsx
@@ -6,8 +6,13 @@ import Label from "@/components/form/Label";
 import Input from "@/components/form/input/InputField";
 import TextArea from "@/components/form/input/TextArea";
 import Button from "@/components/ui/button/Button";
-import { createPlugin } from "@/lib/plugins/createPlugin";
+import { updatePlugin } from "@/lib/plugins/updatePlugin";
+import { Plugin } from "@/lib/plugins/pluginType";
 import { showToast } from "@/lib/toastStore";
+
+interface EditPluginFormProps {
+    plugin: Plugin;
+}
 
 type FormValues = {
     name: string;
@@ -15,24 +20,20 @@ type FormValues = {
     groupId: string;
     artifactId: string;
     description: string;
-    version: string;
-    changeLog: string;
-    configuration: string;
 };
 
 type FormField = keyof FormValues;
 
-type RequiredFormField = "name" | "pluginKey" | "groupId" | "artifactId" | "version";
+type RequiredFormField = "name" | "pluginKey" | "groupId" | "artifactId";
 
 const requiredFields: RequiredFormField[] = [
     "name",
     "pluginKey",
     "groupId",
     "artifactId",
-    "version",
 ];
 
-const EditPluginForm = () => {
+const EditPluginForm = ({ plugin }: EditPluginFormProps) => {
     const router = useRouter();
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
@@ -73,9 +74,6 @@ const EditPluginForm = () => {
             groupId: String(formData.get("groupId") ?? "").trim(),
             artifactId: String(formData.get("artifactId") ?? "").trim(),
             description: String(formData.get("description") ?? "").trim(),
-            version: String(formData.get("version") ?? "").trim(),
-            changeLog: String(formData.get("changeLog") ?? "").trim(),
-            configuration: String(formData.get("configuration") ?? "").trim(),
         };
 
         const validationErrors: Partial<Record<FormField, string>> = {};
@@ -95,28 +93,24 @@ const EditPluginForm = () => {
         setIsSubmitting(true);
 
         try {
-            await createPlugin({
+            await updatePlugin(plugin.id, {
                 name: values.name,
                 pluginKey: values.pluginKey,
                 groupId: values.groupId,
                 artifactId: values.artifactId,
-                version: values.version,
                 description: values.description.length ? values.description : undefined,
-                changeLog: values.changeLog.length ? values.changeLog : undefined,
-                configuration: values.configuration.length ? values.configuration : undefined,
             });
 
             showToast({
                 variant: "success",
-                title: "Plugin created",
-                message: `${values.name} has been created successfully.`,
+                title: "Plugin updated",
+                message: `${values.name} has been updated successfully.`,
                 hideButtonLabel: "Dismiss",
             });
 
-            router.push("/builder/plugins");
+            router.push(`/builder/plugins/${plugin.id}`);
         } catch (error) {
-            // Errors are handled by the API client, so we just log for debugging purposes.
-            console.error("Failed to create plugin", error);
+            console.error("Failed to update plugin", error);
         } finally {
             setIsSubmitting(false);
         }
@@ -133,6 +127,7 @@ const EditPluginForm = () => {
                         id="name"
                         name="name"
                         placeholder="Enter plugin name"
+                        defaultValue={plugin.name}
                         required
                         onChange={handleInputChange("name")}
                         error={Boolean(errors.name)}
@@ -147,6 +142,7 @@ const EditPluginForm = () => {
                         id="pluginKey"
                         name="pluginKey"
                         placeholder="Enter plugin key"
+                        defaultValue={plugin.pluginKey}
                         required
                         onChange={handleInputChange("pluginKey")}
                         error={Boolean(errors.pluginKey)}
@@ -163,6 +159,7 @@ const EditPluginForm = () => {
                         id="groupId"
                         name="groupId"
                         placeholder="Enter group ID"
+                        defaultValue={plugin.groupId}
                         required
                         onChange={handleInputChange("groupId")}
                         error={Boolean(errors.groupId)}
@@ -177,6 +174,7 @@ const EditPluginForm = () => {
                         id="artifactId"
                         name="artifactId"
                         placeholder="Enter artifact ID"
+                        defaultValue={plugin.artifactId}
                         required
                         onChange={handleInputChange("artifactId")}
                         error={Boolean(errors.artifactId)}
@@ -191,38 +189,7 @@ const EditPluginForm = () => {
                     name="description"
                     placeholder="Add plugin description"
                     rows={3}
-                />
-            </div>
-            <div>
-                <Label htmlFor="version">
-                    Version<span className="text-error-500">*</span>
-                </Label>
-                <Input
-                    id="version"
-                    name="version"
-                    placeholder="Enter plugin version"
-                    required
-                    onChange={handleInputChange("version")}
-                    error={Boolean(errors.version)}
-                    hint={errors.version}
-                />
-            </div>
-            <div>
-                <Label htmlFor="changeLog">Change log</Label>
-                <TextArea
-                    id="changeLog"
-                    name="changeLog"
-                    placeholder="Describe the changes in this version"
-                    rows={4}
-                />
-            </div>
-            <div>
-                <Label htmlFor="configuration">Configuration</Label>
-                <TextArea
-                    id="configuration"
-                    name="configuration"
-                    placeholder="Add plugin configuration"
-                    rows={4}
+                    defaultValue={plugin.description}
                 />
             </div>
             <div className="flex justify-end">
@@ -231,7 +198,7 @@ const EditPluginForm = () => {
                     className="min-w-32 justify-center"
                     disabled={isSubmitting}
                 >
-                    {isSubmitting ? "Creating..." : "Create plugin"}
+                    {isSubmitting ? "Saving..." : "Save changes"}
                 </Button>
             </div>
         </form>

--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/edit/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/edit/page.tsx
@@ -1,29 +1,51 @@
-import { Metadata } from "next";
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
 import ComponentCard from "@/components/common/ComponentCard";
+import { ApiError } from "@/lib/apiClient";
+import fetchPluginById from "@/lib/plugins/fetchPluginById";
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
 import EditPluginForm from "./EditPluginForm";
 
 export const metadata: Metadata = {
-    title: "FiG | New plugin",
-    description: "New Plugin page",
+    title: "FiG | Edit plugin",
+    description: "Edit plugin page",
 };
 
-export default async function NewPluginPage() {
-    return (
-        <div>
-            <PageBreadcrumb
-                pageTitle="New plugin"
-                breadcrumbs={[
-                    { label: "Builder" },
-                    { label: "Plugins", href: "/builder/plugins" },
-                    { label: "New plugin" },
-                ]}
-            />
-            <div className="space-y-6">
-                <ComponentCard title="Plugins">
-                    <EditPluginForm />
-                </ComponentCard>
+interface EditPluginPageProps {
+    params: Promise<{
+        pluginId: string;
+    }>;
+}
+
+export default async function EditPluginPage({ params }: EditPluginPageProps) {
+    const { pluginId } = await params;
+
+    try {
+        const plugin = await fetchPluginById(pluginId);
+
+        return (
+            <div>
+                <PageBreadcrumb
+                    pageTitle={`Edit plugin: ${plugin.name}`}
+                    breadcrumbs={[
+                        { label: "Builder" },
+                        { label: "Plugins", href: "/builder/plugins" },
+                        { label: plugin.name, href: `/builder/plugins/${plugin.id}` },
+                        { label: "Edit plugin" },
+                    ]}
+                />
+                <div className="space-y-6">
+                    <ComponentCard title="Edit plugin">
+                        <EditPluginForm plugin={plugin} />
+                    </ComponentCard>
+                </div>
             </div>
-        </div>
-    );
+        );
+    } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+            notFound();
+        }
+
+        throw error;
+    }
 }

--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/versions/[versionId]/edit/EditPluginVersionForm.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/versions/[versionId]/edit/EditPluginVersionForm.tsx
@@ -6,11 +6,13 @@ import Label from "@/components/form/Label";
 import Input from "@/components/form/input/InputField";
 import TextArea from "@/components/form/input/TextArea";
 import Button from "@/components/ui/button/Button";
-import { createPluginVersion } from "@/lib/plugins/createPluginVersion";
+import { PluginVersion } from "@/lib/plugins/pluginType";
+import { updatePluginVersion } from "@/lib/plugins/updatePluginVersion";
 import { showToast } from "@/lib/toastStore";
 
-interface NewPluginVersionFormProps {
-        pluginId: string;
+interface EditPluginVersionFormProps {
+    pluginId: string;
+    pluginVersion: PluginVersion;
 }
 
 type FormValues = {
@@ -24,7 +26,7 @@ type RequiredFormField = "version" | "configuration";
 
 const requiredFields: RequiredFormField[] = ["version", "configuration"];
 
-const EditPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
+const EditPluginVersionForm = ({ pluginId, pluginVersion }: EditPluginVersionFormProps) => {
     const router = useRouter();
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
@@ -92,7 +94,7 @@ const EditPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
         setIsSubmitting(true);
 
         try {
-            await createPluginVersion(pluginId, {
+            await updatePluginVersion(pluginId, pluginVersion.id, {
                 version: values.version,
                 configuration: values.configuration,
                 changeLog: values.changeLog.length ? values.changeLog : undefined,
@@ -100,14 +102,14 @@ const EditPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
 
             showToast({
                 variant: "success",
-                title: "Plugin version created",
-                message: `Version ${values.version} has been created successfully.`,
+                title: "Plugin version updated",
+                message: `Version ${values.version} has been updated successfully.`,
                 hideButtonLabel: "Dismiss",
             });
 
             router.push(`/builder/plugins/${pluginId}`);
         } catch (error) {
-            console.error("Failed to create plugin version", error);
+            console.error("Failed to update plugin version", error);
         } finally {
             setIsSubmitting(false);
         }
@@ -123,6 +125,7 @@ const EditPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
                     id="version"
                     name="version"
                     placeholder="Enter plugin version"
+                    defaultValue={pluginVersion.version}
                     required
                     onChange={handleRequiredInputChange("version")}
                     error={Boolean(errors.version)}
@@ -136,6 +139,7 @@ const EditPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
                     name="changeLog"
                     placeholder="Add change log notes"
                     rows={4}
+                    defaultValue={pluginVersion.changeLog}
                 />
             </div>
             <div>
@@ -147,6 +151,7 @@ const EditPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
                     name="configuration"
                     placeholder="Add plugin configuration"
                     rows={6}
+                    defaultValue={pluginVersion.configuration}
                     onChange={handleConfigurationChange}
                     error={Boolean(errors.configuration)}
                     hint={errors.configuration}
@@ -158,7 +163,7 @@ const EditPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
                     className="min-w-32 justify-center"
                     disabled={isSubmitting}
                 >
-                    {isSubmitting ? "Creating..." : "Create version"}
+                    {isSubmitting ? "Saving..." : "Save changes"}
                 </Button>
             </div>
         </form>

--- a/src/components/form/input/TextArea.tsx
+++ b/src/components/form/input/TextArea.tsx
@@ -8,6 +8,7 @@ interface TextareaProps {
   placeholder?: string; // Placeholder text
   rows?: number; // Number of rows
   value?: string; // Current value
+  defaultValue?: string; // Default value
   onChange?: (value: string) => void; // Change handler
   className?: string; // Additional CSS classes
   disabled?: boolean; // Disabled state
@@ -21,6 +22,7 @@ const TextArea: React.FC<TextareaProps> = ({
   placeholder = "Enter your message", // Default placeholder
   rows = 3, // Default number of rows
   value, // Current value
+  defaultValue, // Default value
   onChange, // Callback for changes
   className = "", // Additional custom styles
   disabled = false, // Disabled state
@@ -53,7 +55,11 @@ const TextArea: React.FC<TextareaProps> = ({
         onChange={handleChange}
         disabled={disabled}
         className={textareaClasses}
-        {...(value !== undefined ? { value } : {})}
+        {...(value !== undefined
+          ? { value }
+          : defaultValue !== undefined
+          ? { defaultValue }
+          : {})}
       />
       {hint && (
         <p

--- a/src/lib/plugins/updatePlugin.ts
+++ b/src/lib/plugins/updatePlugin.ts
@@ -1,0 +1,26 @@
+import { fetchData } from "@/lib/apiClient";
+import { Plugin } from "@/lib/plugins/pluginType";
+
+export interface UpdatePluginPayload {
+    name: string;
+    pluginKey: string;
+    groupId: string;
+    artifactId: string;
+    description?: string;
+}
+
+export const updatePlugin = async (
+    pluginId: string | number,
+    payload: UpdatePluginPayload,
+): Promise<Plugin> => {
+    return fetchData<Plugin>(`/v1/plugins/${pluginId}`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            accept: "*/*",
+        },
+        body: JSON.stringify(payload),
+    });
+};
+
+export default updatePlugin;

--- a/src/lib/plugins/updatePluginVersion.ts
+++ b/src/lib/plugins/updatePluginVersion.ts
@@ -1,0 +1,25 @@
+import { fetchData } from "@/lib/apiClient";
+import { PluginVersion } from "@/lib/plugins/pluginType";
+
+export interface UpdatePluginVersionPayload {
+    version: string;
+    changeLog?: string;
+    configuration: string;
+}
+
+export const updatePluginVersion = async (
+    pluginId: string | number,
+    versionId: string | number,
+    payload: UpdatePluginVersionPayload,
+): Promise<PluginVersion> => {
+    return fetchData<PluginVersion>(`/v1/plugins/${pluginId}/versions/${versionId}`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            accept: "*/*",
+        },
+        body: JSON.stringify(payload),
+    });
+};
+
+export default updatePluginVersion;


### PR DESCRIPTION
## Summary
- update plugin edit form to submit existing plugin data to the update endpoint and preload current values
- update plugin version edit form to submit to the version update endpoint with existing data filled in
- add API clients for updating plugins and versions and support default values in the textarea component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d079d7ada883329a0edaf09a2fbe1f