### PR TITLE
Add edit and delete actions to plugin management pages

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/page.tsx
@@ -3,6 +3,7 @@ import ComponentCard from "@/components/common/ComponentCard";
 import PluginVersionsTable from "@/components/tables/PluginVersionsTable";
 import { ApiError } from "@/lib/apiClient";
 import fetchPluginById from "@/lib/plugins/fetchPluginById";
+import Link from "next/link";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -14,10 +15,10 @@ export const metadata: Metadata = {
 interface PluginPageProps {
     params: Promise<{
         pluginId: string;
-    }>
+    }>;
 }
 
-export default async function PluginPage({params}: PluginPageProps) {
+export default async function PluginPage({ params }: PluginPageProps) {
     const { pluginId } = await params;
 
     try {
@@ -34,7 +35,17 @@ export default async function PluginPage({params}: PluginPageProps) {
                     ]}
                 />
                 <div className="space-y-6">
-                    <ComponentCard title="Plugin details">
+                    <ComponentCard
+                        title="Plugin details"
+                        action={
+                            <Link
+                                href={`/builder/plugins/${plugin.id}/edit`}
+                                className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white shadow-theme-xs transition-colors hover:bg-brand-600"
+                            >
+                                Edit
+                            </Link>
+                        }
+                    >
                         <div className="grid gap-6 md:grid-cols-2">
                             <div>
                                 <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Plugin ID</p>

--- a/src/components/tables/PluginsTable.tsx
+++ b/src/components/tables/PluginsTable.tsx
@@ -4,23 +4,51 @@ import React, { useCallback, useMemo } from "react";
 
 import ConfigurableTable, { TableConfig } from "@/components/tables/ConfigurableTable";
 import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
+import { fetchData } from "@/lib/apiClient";
 import { Plugin } from "@/lib/plugins/pluginType";
+import { showToast } from "@/lib/toastStore";
 import { useRouter } from "next/navigation";
 
 interface PluginsTableProps {
     data: Plugin[];
 }
 
-const PluginsTable = ({data}: PluginsTableProps) => {
+const PluginsTable = ({ data }: PluginsTableProps) => {
     const router = useRouter();
 
-    const handleEditPlugin = useCallback((plugin: Plugin) => {
-        console.log(`Edit plugin ${plugin.id}`);
-    }, []);
+    const handleEditPlugin = useCallback(
+        (plugin: Plugin) => {
+            router.push(`/builder/plugins/${plugin.id}/edit`);
+        },
+        [router],
+    );
 
-    const handleRemovePlugin = useCallback((plugin: Plugin) => {
-        console.log(`Remove plugin ${plugin.id}`);
-    }, []);
+    const handleRemovePlugin = useCallback(
+        async (plugin: Plugin) => {
+            const confirmed = window.confirm("If user sure to delete?");
+            if (!confirmed) {
+                return;
+            }
+
+            try {
+                await fetchData<void>(`/v1/plugins/${plugin.id}`, {
+                    method: "DELETE",
+                });
+
+                showToast({
+                    variant: "success",
+                    title: "Plugin removed",
+                    message: `${plugin.name} has been removed successfully.`,
+                    hideButtonLabel: "Dismiss",
+                });
+
+                router.refresh();
+            } catch (error) {
+                console.error(`Failed to remove plugin ${plugin.id}`, error);
+            }
+        },
+        [router],
+    );
 
     const handleNavigateToPlugin = useCallback(
         (plugin: Plugin) => {


### PR DESCRIPTION
## Summary
- add an Edit shortcut to the plugin details card
- wire PluginVersionsTable actions to navigate to edit and delete versions with confirmation
- enable plugin list actions to edit plugins or delete them with confirmation and success feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d07e511a48833290c02a51db35dd13