### PR TITLE
Implement game management flows

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/EditGameForm.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/EditGameForm.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import Button from "@/components/ui/button/Button";
+import { Game } from "@/lib/games/gameType";
+import { updateGame } from "@/lib/games/updateGame";
+import { showToast } from "@/lib/toastStore";
+
+type FormField = "name" | "gameKey";
+
+interface EditGameFormProps {
+  game: Game;
+}
+
+const EditGameForm = ({ game }: EditGameFormProps) => {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
+
+  const handleInputChange = (field: FormField) => (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    if (!errors[field]) {
+      return;
+    }
+
+    const trimmedValue = event.target.value.trim();
+    if (!trimmedValue.length) {
+      return;
+    }
+
+    setErrors((previousErrors) => {
+      const updated = { ...previousErrors };
+      delete updated[field];
+      return updated;
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const name = String(formData.get("name") ?? "").trim();
+    const gameKey = String(formData.get("gameKey") ?? "").trim();
+
+    const validationErrors: Partial<Record<FormField, string>> = {};
+
+    if (!name.length) {
+      validationErrors.name = "This field is required.";
+    }
+
+    if (!gameKey.length) {
+      validationErrors.gameKey = "This field is required.";
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await updateGame(game.id, {
+        name,
+        gameKey,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Game updated",
+        message: `${name} has been updated successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      router.push(`/builder/games/${game.id}`);
+      router.refresh();
+    } catch (error) {
+      console.error(`Failed to update game ${game.id}`, error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+        <div>
+          <Label htmlFor="name">
+            Name<span className="text-error-500">*</span>
+          </Label>
+          <Input
+            id="name"
+            name="name"
+            defaultValue={game.name}
+            placeholder="Enter game name"
+            required
+            onChange={handleInputChange("name")}
+            error={Boolean(errors.name)}
+            hint={errors.name}
+          />
+        </div>
+        <div>
+          <Label htmlFor="gameKey">
+            Game key<span className="text-error-500">*</span>
+          </Label>
+          <Input
+            id="gameKey"
+            name="gameKey"
+            defaultValue={game.gameKey}
+            placeholder="Enter game key"
+            required
+            onChange={handleInputChange("gameKey")}
+            error={Boolean(errors.gameKey)}
+            hint={errors.gameKey}
+          />
+        </div>
+      </div>
+      <div>
+        <Label>Studio ID</Label>
+        <Input readOnly value={game.studioId ?? "—"} />
+      </div>
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Saving..." : "Save changes"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push(`/builder/games/${game.id}`)}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default EditGameForm;

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/edit/EditGameConfigurationForm.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/edit/EditGameConfigurationForm.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import TextArea from "@/components/form/input/TextArea";
+import Button from "@/components/ui/button/Button";
+import { GameConfiguration } from "@/lib/game-configurations/gameConfigurationType";
+import { updateGameConfiguration } from "@/lib/game-configurations/updateGameConfiguration";
+import { showToast } from "@/lib/toastStore";
+
+type FormField = "name" | "configuration";
+
+interface EditGameConfigurationFormProps {
+  configuration: GameConfiguration;
+}
+
+const EditGameConfigurationForm = ({
+  configuration,
+}: EditGameConfigurationFormProps) => {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
+
+  const clearErrorIfNeeded = (field: FormField, value: string) => {
+    if (!errors[field]) {
+      return;
+    }
+
+    const trimmedValue = value.trim();
+    if (!trimmedValue.length) {
+      return;
+    }
+
+    setErrors((previousErrors) => {
+      const updated = { ...previousErrors };
+      delete updated[field];
+      return updated;
+    });
+  };
+
+  const handleInputChange = (field: FormField) => (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    clearErrorIfNeeded(field, event.target.value);
+  };
+
+  const handleTextAreaChange = (field: FormField) => (value: string) => {
+    clearErrorIfNeeded(field, value);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const name = String(formData.get("name") ?? "").trim();
+    const configurationValue = String(formData.get("configuration") ?? "").trim();
+
+    const validationErrors: Partial<Record<FormField, string>> = {};
+
+    if (!name.length) {
+      validationErrors.name = "This field is required.";
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await updateGameConfiguration(configuration.id, {
+        name,
+        configuration: configurationValue.length
+          ? configurationValue
+          : undefined,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Game configuration updated",
+        message: `${name} has been updated successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      router.push(`/builder/games/${configuration.gameId}`);
+      router.refresh();
+    } catch (error) {
+      console.error(
+        `Failed to update game configuration ${configuration.id}`,
+        error
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+      <div className="max-w-md">
+        <Label htmlFor="name">
+          Name<span className="text-error-500">*</span>
+        </Label>
+        <Input
+          id="name"
+          name="name"
+          defaultValue={configuration.name}
+          placeholder="Enter configuration name"
+          required
+          onChange={handleInputChange("name")}
+          error={Boolean(errors.name)}
+          hint={errors.name}
+        />
+      </div>
+      <div>
+        <Label htmlFor="configuration">Configuration</Label>
+        <TextArea
+          id="configuration"
+          name="configuration"
+          rows={6}
+          defaultValue={configuration.configuration ?? ""}
+          placeholder="Add configuration"
+          onChange={handleTextAreaChange("configuration")}
+          error={Boolean(errors.configuration)}
+          hint={errors.configuration}
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Saving..." : "Save changes"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push(`/builder/games/${configuration.gameId}`)}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default EditGameConfigurationForm;

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/edit/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/edit/page.tsx
@@ -1,0 +1,64 @@
+import { Metadata } from "next";
+
+import ComponentCard from "@/components/common/ComponentCard";
+import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+import { fetchGameById } from "@/lib/games/fetchGameById";
+import { fetchGameConfiguration } from "@/lib/game-configurations/fetchGameConfiguration";
+
+import EditGameConfigurationForm from "./EditGameConfigurationForm";
+
+export const metadata: Metadata = {
+  title: "FiG | Edit game configuration",
+  description: "Edit game configuration",
+};
+
+interface EditGameConfigurationPageProps {
+  params: {
+    gameId: string;
+    configurationId: string;
+  };
+}
+
+const parseId = (value: string): number => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("Invalid identifier");
+  }
+
+  return parsed;
+};
+
+export default async function EditGameConfigurationPage({
+  params,
+}: EditGameConfigurationPageProps) {
+  const gameId = parseId(params.gameId);
+  const configurationId = parseId(params.configurationId);
+
+  const [game, configuration] = await Promise.all([
+    fetchGameById(gameId),
+    fetchGameConfiguration(configurationId),
+  ]);
+
+  if (configuration.gameId !== game.id) {
+    throw new Error("Configuration does not belong to the provided game");
+  }
+
+  return (
+    <div>
+      <PageBreadcrumb
+        pageTitle={`Edit configuration: ${configuration.name}`}
+        breadcrumbs={[
+          { label: "Builder" },
+          { label: "All Builded Games", href: "/builder/games" },
+          { label: game.name, href: `/builder/games/${game.id}` },
+          { label: "Edit Configuration" },
+        ]}
+      />
+      <div className="space-y-6">
+        <ComponentCard title="Edit configuration">
+          <EditGameConfigurationForm configuration={configuration} />
+        </ComponentCard>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/new/NewGameConfigurationForm.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/new/NewGameConfigurationForm.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import TextArea from "@/components/form/input/TextArea";
+import Button from "@/components/ui/button/Button";
+import { createGameConfiguration } from "@/lib/game-configurations/createGameConfiguration";
+import { showToast } from "@/lib/toastStore";
+
+type FormField = "name" | "configuration";
+
+interface NewGameConfigurationFormProps {
+  gameId: number;
+}
+
+const NewGameConfigurationForm = ({ gameId }: NewGameConfigurationFormProps) => {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
+
+  const clearErrorIfNeeded = (field: FormField, value: string) => {
+    if (!errors[field]) {
+      return;
+    }
+
+    const trimmedValue = value.trim();
+    if (!trimmedValue.length) {
+      return;
+    }
+
+    setErrors((previousErrors) => {
+      const updated = { ...previousErrors };
+      delete updated[field];
+      return updated;
+    });
+  };
+
+  const handleInputChange = (field: FormField) => (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    clearErrorIfNeeded(field, event.target.value);
+  };
+
+  const handleTextAreaChange = (field: FormField) => (value: string) => {
+    clearErrorIfNeeded(field, value);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const name = String(formData.get("name") ?? "").trim();
+    const configuration = String(formData.get("configuration") ?? "").trim();
+
+    const validationErrors: Partial<Record<FormField, string>> = {};
+
+    if (!name.length) {
+      validationErrors.name = "This field is required.";
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await createGameConfiguration({
+        gameId,
+        name,
+        configuration: configuration.length ? configuration : undefined,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Game configuration created",
+        message: `${name} has been created successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      router.push(`/builder/games/${gameId}`);
+      router.refresh();
+    } catch (error) {
+      console.error("Failed to create game configuration", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+      <div className="max-w-md">
+        <Label htmlFor="name">
+          Name<span className="text-error-500">*</span>
+        </Label>
+        <Input
+          id="name"
+          name="name"
+          placeholder="Enter configuration name"
+          required
+          onChange={handleInputChange("name")}
+          error={Boolean(errors.name)}
+          hint={errors.name}
+        />
+      </div>
+      <div>
+        <Label htmlFor="configuration">Configuration</Label>
+        <TextArea
+          id="configuration"
+          name="configuration"
+          rows={6}
+          placeholder="Add configuration"
+          onChange={handleTextAreaChange("configuration")}
+          error={Boolean(errors.configuration)}
+          hint={errors.configuration}
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Creating..." : "Create configuration"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push(`/builder/games/${gameId}`)}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default NewGameConfigurationForm;

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/new/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/new/page.tsx
@@ -1,0 +1,51 @@
+import { Metadata } from "next";
+
+import ComponentCard from "@/components/common/ComponentCard";
+import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+
+import NewGameConfigurationForm from "./NewGameConfigurationForm";
+
+export const metadata: Metadata = {
+  title: "FiG | New game configuration",
+  description: "Create a new game configuration",
+};
+
+interface NewGameConfigurationPageProps {
+  params: {
+    gameId: string;
+  };
+}
+
+const parseGameId = (value: string): number => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("Invalid game id");
+  }
+
+  return parsed;
+};
+
+export default async function NewGameConfigurationPage({
+  params,
+}: NewGameConfigurationPageProps) {
+  const gameId = parseGameId(params.gameId);
+
+  return (
+    <div>
+      <PageBreadcrumb
+        pageTitle="New Game Configuration"
+        breadcrumbs={[
+          { label: "Builder" },
+          { label: "All Builded Games", href: "/builder/games" },
+          { label: `Game ${gameId}`, href: `/builder/games/${gameId}` },
+          { label: "New Game Configuration" },
+        ]}
+      />
+      <div className="space-y-6">
+        <ComponentCard title="New configuration">
+          <NewGameConfigurationForm gameId={gameId} />
+        </ComponentCard>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/edit/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/edit/page.tsx
@@ -1,0 +1,51 @@
+import { Metadata } from "next";
+
+import ComponentCard from "@/components/common/ComponentCard";
+import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+import { fetchGameById } from "@/lib/games/fetchGameById";
+
+import EditGameForm from "../EditGameForm";
+
+export const metadata: Metadata = {
+  title: "FiG | Edit game",
+  description: "Edit game",
+};
+
+interface EditGamePageProps {
+  params: {
+    gameId: string;
+  };
+}
+
+const parseGameId = (value: string): number => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("Invalid game id");
+  }
+
+  return parsed;
+};
+
+export default async function EditGamePage({ params }: EditGamePageProps) {
+  const gameId = parseGameId(params.gameId);
+  const game = await fetchGameById(gameId);
+
+  return (
+    <div>
+      <PageBreadcrumb
+        pageTitle={`Edit ${game.name}`}
+        breadcrumbs={[
+          { label: "Builder" },
+          { label: "All Builded Games", href: "/builder/games" },
+          { label: game.name, href: `/builder/games/${game.id}` },
+          { label: "Edit" },
+        ]}
+      />
+      <div className="space-y-6">
+        <ComponentCard title="Edit game">
+          <EditGameForm game={game} />
+        </ComponentCard>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/page.tsx
@@ -1,38 +1,87 @@
-import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+import Link from "next/link";
 import { Metadata } from "next";
-import React from "react";
+
+import ComponentCard from "@/components/common/ComponentCard";
+import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+import GameConfigurationsTable from "@/components/tables/GameConfigurationsTable";
+import { fetchGameById } from "@/lib/games/fetchGameById";
+import { fetchGameConfigurations } from "@/lib/game-configurations/fetchGameConfigurations";
 
 export const metadata: Metadata = {
-    title: "Next.js Blank Page | TailAdmin - Next.js Dashboard Template",
-    description: "This is Next.js Blank Page TailAdmin Dashboard Template",
+  title: "FiG | Game details",
+  description: "Game details page",
 };
 
-
 interface GamePageProps {
-    params: {
-        gameId: string;
-    };
+  params: {
+    gameId: string;
+  };
 }
 
-export default function GamePage({params}: GamePageProps) {
+const parseGameId = (value: string): number => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("Invalid game id");
+  }
 
-    const gameId = params.gameId;
+  return parsed;
+};
 
-    return (
-        <div>
-            <PageBreadcrumb pageTitle={`Game ${gameId}`}/>
-            <div
-                className="min-h-screen rounded-2xl border border-gray-200 bg-white px-5 py-7 dark:border-gray-800 dark:bg-white/[0.03] xl:px-10 xl:py-12">
-                <div className="mx-auto w-full max-w-[630px] text-center">
-                    <h3 className="mb-4 font-semibold text-gray-800 text-theme-xl dark:text-white/90 sm:text-2xl">
-                        Card Title Here
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 sm:text-base">
-                        Start putting content on grids or panels, you can also use different
-                        combinations of grids.Please check out the dashboard and other pages
-                    </p>
-                </div>
+export default async function GamePage({ params }: GamePageProps) {
+  const gameId = parseGameId(params.gameId);
+  const [game, configurations] = await Promise.all([
+    fetchGameById(gameId),
+    fetchGameConfigurations(gameId),
+  ]);
+
+  return (
+    <div>
+      <PageBreadcrumb
+        pageTitle={game.name}
+        breadcrumbs={[
+          { label: "Builder" },
+          { label: "All Builded Games", href: "/builder/games" },
+          { label: game.name },
+        ]}
+      />
+      <div className="space-y-6">
+        <ComponentCard title="Game details">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">ID</p>
+              <p className="text-base font-semibold text-gray-800 dark:text-white/90">{game.id}</p>
             </div>
-        </div>
-    );
+            <div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Game key</p>
+              <p className="text-base font-semibold text-gray-800 dark:text-white/90">{game.gameKey}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Name</p>
+              <p className="text-base font-semibold text-gray-800 dark:text-white/90">{game.name}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Studio ID</p>
+              <p className="text-base font-semibold text-gray-800 dark:text-white/90">
+                {game.studioId ?? "—"}
+              </p>
+            </div>
+          </div>
+        </ComponentCard>
+
+        <ComponentCard
+          title="Game configurations"
+          action={
+            <Link
+              href={`/builder/games/${game.id}/configurations/new`}
+              className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white shadow-theme-xs transition-colors hover:bg-brand-600"
+            >
+              New Game Configuration
+            </Link>
+          }
+        >
+          <GameConfigurationsTable gameId={game.id} data={configurations} />
+        </ComponentCard>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(admin)/(builder)/builder/games/new/NewGameForm.tsx
+++ b/src/app/(admin)/(builder)/builder/games/new/NewGameForm.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import Button from "@/components/ui/button/Button";
+import { createGame } from "@/lib/games/createGame";
+import { showToast } from "@/lib/toastStore";
+
+type FormValues = {
+  name: string;
+  gameKey: string;
+  studioId: string;
+};
+
+type FormField = keyof FormValues;
+
+const REQUIRED_FIELDS: FormField[] = ["name", "gameKey", "studioId"];
+
+const DEFAULT_STUDIO_ID = "1";
+
+const NewGameForm = () => {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
+
+  const initialValues = useMemo<FormValues>(
+    () => ({
+      name: "",
+      gameKey: "",
+      studioId: DEFAULT_STUDIO_ID,
+    }),
+    []
+  );
+
+  const handleInputChange = (field: FormField) => (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    if (!errors[field]) {
+      return;
+    }
+
+    const trimmedValue = event.target.value.trim();
+    if (!trimmedValue.length) {
+      return;
+    }
+
+    setErrors((previousErrors) => {
+      const updated = { ...previousErrors };
+      delete updated[field];
+      return updated;
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const values: FormValues = {
+      name: String(formData.get("name") ?? "").trim(),
+      gameKey: String(formData.get("gameKey") ?? "").trim(),
+      studioId: String(formData.get("studioId") ?? "").trim(),
+    };
+
+    const validationErrors: Partial<Record<FormField, string>> = {};
+
+    REQUIRED_FIELDS.forEach((field) => {
+      if (!values[field].length) {
+        validationErrors[field] = "This field is required.";
+      }
+    });
+
+    const studioIdNumber = Number(values.studioId);
+    if (!Number.isInteger(studioIdNumber) || studioIdNumber <= 0) {
+      validationErrors.studioId = "Studio ID must be a positive number.";
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await createGame({
+        name: values.name,
+        gameKey: values.gameKey,
+        studioId: studioIdNumber,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Game created",
+        message: `${values.name} has been created successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      router.push("/builder/games");
+    } catch (error) {
+      console.error("Failed to create game", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+        <div>
+          <Label htmlFor="name">
+            Name<span className="text-error-500">*</span>
+          </Label>
+          <Input
+            id="name"
+            name="name"
+            placeholder="Enter game name"
+            required
+            onChange={handleInputChange("name")}
+            error={Boolean(errors.name)}
+            hint={errors.name}
+          />
+        </div>
+        <div>
+          <Label htmlFor="gameKey">
+            Game key<span className="text-error-500">*</span>
+          </Label>
+          <Input
+            id="gameKey"
+            name="gameKey"
+            placeholder="Enter game key"
+            required
+            onChange={handleInputChange("gameKey")}
+            error={Boolean(errors.gameKey)}
+            hint={errors.gameKey}
+          />
+        </div>
+      </div>
+      <div className="max-w-md">
+        <Label htmlFor="studioId">
+          Studio ID<span className="text-error-500">*</span>
+        </Label>
+        <Input
+          id="studioId"
+          name="studioId"
+          defaultValue={initialValues.studioId}
+          readOnly
+          onChange={handleInputChange("studioId")}
+          error={Boolean(errors.studioId)}
+          hint={errors.studioId}
+        />
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          The studio is pre-selected for now and will be taken from authentication data in the future.
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Creating..." : "Create game"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push("/builder/games")}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default NewGameForm;

--- a/src/app/(admin)/(builder)/builder/games/new/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/new/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
 import ComponentCard from "@/components/common/ComponentCard";
+import NewGameForm from "./NewGameForm";
 
 export const metadata: Metadata = {
     title: "FiG | Builder | New game",
@@ -21,7 +22,7 @@ export default async function NewPluginPage() {
             />
             <div className="space-y-6">
                 <ComponentCard title="New game">
-                    <div>Content</div>
+                    <NewGameForm />
                 </ComponentCard>
             </div>
         </div>

--- a/src/components/tables/GameConfigurationsTable.tsx
+++ b/src/components/tables/GameConfigurationsTable.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+
+import ConfigurableTable, { TableConfig } from "@/components/tables/ConfigurableTable";
+import { GameConfiguration } from "@/lib/game-configurations/gameConfigurationType";
+
+interface GameConfigurationsTableProps {
+  gameId: number;
+  data: GameConfiguration[];
+}
+
+const GameConfigurationsTable = ({ gameId, data }: GameConfigurationsTableProps) => {
+  const router = useRouter();
+
+  const handleEditConfiguration = useCallback(
+    (configuration: GameConfiguration) => {
+      router.push(
+        `/builder/games/${gameId}/configurations/${configuration.id}/edit`
+      );
+    },
+    [gameId, router]
+  );
+
+  const tableConfig = useMemo<TableConfig<GameConfiguration>>(
+    () => ({
+      name: "Configurations",
+      enablePagination: false,
+      enableSearch: false,
+      enableSorting: false,
+      getRowKey: (row) => row.id,
+      actions: {
+        align: "end",
+        edit: {
+          label: "Edit",
+          onClick: handleEditConfiguration,
+        },
+      },
+      onRowClick: handleEditConfiguration,
+      fields: [
+        {
+          key: "id",
+          label: "ID",
+          dataKey: "id",
+        },
+        {
+          key: "name",
+          label: "Name",
+          dataKey: "name",
+        },
+        {
+          key: "configuration",
+          label: "Configuration",
+          render: (row) => row.configuration ?? "—",
+        },
+      ],
+    }),
+    [handleEditConfiguration]
+  );
+
+  return <ConfigurableTable data={data} config={tableConfig} />;
+};
+
+export default GameConfigurationsTable;

--- a/src/lib/game-configurations/createGameConfiguration.ts
+++ b/src/lib/game-configurations/createGameConfiguration.ts
@@ -1,0 +1,23 @@
+import { fetchData } from "@/lib/apiClient";
+import { GameConfiguration } from "@/lib/game-configurations/gameConfigurationType";
+
+export interface CreateGameConfigurationPayload {
+  gameId: number;
+  name: string;
+  configuration?: string;
+}
+
+export const createGameConfiguration = async (
+  payload: CreateGameConfigurationPayload
+): Promise<GameConfiguration> => {
+  return fetchData<GameConfiguration>("/v1/game-configurations", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default createGameConfiguration;

--- a/src/lib/game-configurations/fetchGameConfiguration.ts
+++ b/src/lib/game-configurations/fetchGameConfiguration.ts
@@ -1,0 +1,15 @@
+import { fetchData } from "@/lib/apiClient";
+import { GameConfiguration } from "@/lib/game-configurations/gameConfigurationType";
+
+export const fetchGameConfiguration = async (
+  configurationId: number
+): Promise<GameConfiguration> => {
+  return fetchData<GameConfiguration>(
+    `/v1/game-configurations/${configurationId}`,
+    {
+      cache: "no-store",
+    }
+  );
+};
+
+export default fetchGameConfiguration;

--- a/src/lib/game-configurations/fetchGameConfigurations.ts
+++ b/src/lib/game-configurations/fetchGameConfigurations.ts
@@ -1,0 +1,26 @@
+import { fetchData } from "@/lib/apiClient";
+import {
+  GameConfiguration,
+  GameConfigurationsResponse,
+} from "@/lib/game-configurations/gameConfigurationType";
+
+const normalizeResponse = (
+  response: GameConfigurationsResponse
+): GameConfiguration[] => {
+  return response.content ?? [];
+};
+
+export const fetchGameConfigurations = async (
+  gameId: number
+): Promise<GameConfiguration[]> => {
+  const response = await fetchData<GameConfigurationsResponse>(
+    `/v1/game-configurations?gameId=${gameId}`,
+    {
+      cache: "no-store",
+    }
+  );
+
+  return normalizeResponse(response);
+};
+
+export default fetchGameConfigurations;

--- a/src/lib/game-configurations/gameConfigurationType.ts
+++ b/src/lib/game-configurations/gameConfigurationType.ts
@@ -1,0 +1,13 @@
+export interface GameConfiguration {
+  id: number;
+  gameId: number;
+  name: string;
+  configuration?: string | null;
+}
+
+export interface GameConfigurationsResponse {
+  content: GameConfiguration[];
+  totalElements: number;
+  page: number;
+  size: number;
+}

--- a/src/lib/game-configurations/updateGameConfiguration.ts
+++ b/src/lib/game-configurations/updateGameConfiguration.ts
@@ -1,0 +1,23 @@
+import { fetchData } from "@/lib/apiClient";
+import { GameConfiguration } from "@/lib/game-configurations/gameConfigurationType";
+
+export interface UpdateGameConfigurationPayload {
+  name: string;
+  configuration?: string;
+}
+
+export const updateGameConfiguration = async (
+  configurationId: number,
+  payload: UpdateGameConfigurationPayload
+): Promise<GameConfiguration> => {
+  return fetchData<GameConfiguration>(`/v1/game-configurations/${configurationId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default updateGameConfiguration;

--- a/src/lib/games/createGame.ts
+++ b/src/lib/games/createGame.ts
@@ -1,0 +1,21 @@
+import { fetchData } from "@/lib/apiClient";
+import { Game } from "@/lib/games/gameType";
+
+export interface CreateGamePayload {
+  gameKey: string;
+  name: string;
+  studioId: number;
+}
+
+export const createGame = async (payload: CreateGamePayload): Promise<Game> => {
+  return fetchData<Game>("/v1/games", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default createGame;

--- a/src/lib/games/deleteGame.ts
+++ b/src/lib/games/deleteGame.ts
@@ -1,0 +1,9 @@
+import { fetchData } from "@/lib/apiClient";
+
+export const deleteGame = async (gameId: number): Promise<void> => {
+  await fetchData<void>(`/v1/games/${gameId}`, {
+    method: "DELETE",
+  });
+};
+
+export default deleteGame;

--- a/src/lib/games/fetchGameById.ts
+++ b/src/lib/games/fetchGameById.ts
@@ -1,0 +1,10 @@
+import { fetchData } from "@/lib/apiClient";
+import { Game } from "@/lib/games/gameType";
+
+export const fetchGameById = async (gameId: number): Promise<Game> => {
+  return fetchData<Game>(`/v1/games/${gameId}`, {
+    cache: "no-store",
+  });
+};
+
+export default fetchGameById;

--- a/src/lib/games/updateGame.ts
+++ b/src/lib/games/updateGame.ts
@@ -1,0 +1,23 @@
+import { fetchData } from "@/lib/apiClient";
+import { Game } from "@/lib/games/gameType";
+
+export interface UpdateGamePayload {
+  gameKey: string;
+  name: string;
+}
+
+export const updateGame = async (
+  gameId: number,
+  payload: UpdateGamePayload
+): Promise<Game> => {
+  return fetchData<Game>(`/v1/games/${gameId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default updateGame;


### PR DESCRIPTION
## Summary
- replace the games table expandable section with navigation, edit, and delete actions that confirm removal
- add create and edit game forms with validation that POST/PUT to the games API
- build game detail and configuration management pages with tables and forms backed by new fetch helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1dc36b2548332bace98226fa6dfb0