### PR TITLE
Fix awaiting of params in game routes

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/edit/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/edit/page.tsx
@@ -13,10 +13,10 @@ export const metadata: Metadata = {
 };
 
 interface EditGameConfigurationPageProps {
-  params: {
+  params: Promise<{
     gameId: string;
     configurationId: string;
-  };
+  }>;
 }
 
 const parseId = (value: string): number => {
@@ -31,8 +31,10 @@ const parseId = (value: string): number => {
 export default async function EditGameConfigurationPage({
   params,
 }: EditGameConfigurationPageProps) {
-  const gameId = parseId(params.gameId);
-  const configurationId = parseId(params.configurationId);
+  const { gameId: gameIdParam, configurationId: configurationIdParam } =
+    await params;
+  const gameId = parseId(gameIdParam);
+  const configurationId = parseId(configurationIdParam);
 
   const [game, configuration] = await Promise.all([
     fetchGameById(gameId),

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/new/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/new/page.tsx
@@ -11,9 +11,9 @@ export const metadata: Metadata = {
 };
 
 interface NewGameConfigurationPageProps {
-  params: {
+  params: Promise<{
     gameId: string;
-  };
+  }>;
 }
 
 const parseGameId = (value: string): number => {
@@ -28,7 +28,8 @@ const parseGameId = (value: string): number => {
 export default async function NewGameConfigurationPage({
   params,
 }: NewGameConfigurationPageProps) {
-  const gameId = parseGameId(params.gameId);
+  const { gameId: gameIdParam } = await params;
+  const gameId = parseGameId(gameIdParam);
 
   return (
     <div>

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/edit/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/edit/page.tsx
@@ -12,9 +12,9 @@ export const metadata: Metadata = {
 };
 
 interface EditGamePageProps {
-  params: {
+  params: Promise<{
     gameId: string;
-  };
+  }>;
 }
 
 const parseGameId = (value: string): number => {
@@ -27,7 +27,8 @@ const parseGameId = (value: string): number => {
 };
 
 export default async function EditGamePage({ params }: EditGamePageProps) {
-  const gameId = parseGameId(params.gameId);
+  const { gameId: gameIdParam } = await params;
+  const gameId = parseGameId(gameIdParam);
   const game = await fetchGameById(gameId);
 
   return (

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/page.tsx
@@ -13,9 +13,9 @@ export const metadata: Metadata = {
 };
 
 interface GamePageProps {
-  params: {
+  params: Promise<{
     gameId: string;
-  };
+  }>;
 }
 
 const parseGameId = (value: string): number => {
@@ -28,7 +28,8 @@ const parseGameId = (value: string): number => {
 };
 
 export default async function GamePage({ params }: GamePageProps) {
-  const gameId = parseGameId(params.gameId);
+  const { gameId: gameIdParam } = await params;
+  const gameId = parseGameId(gameIdParam);
   const [game, configurations] = await Promise.all([
     fetchGameById(gameId),
     fetchGameConfigurations(gameId),

--- a/src/app/(admin)/(rgs)/games/[gameId]/page.tsx
+++ b/src/app/(admin)/(rgs)/games/[gameId]/page.tsx
@@ -9,14 +9,13 @@ export const metadata: Metadata = {
 
 
 interface GamePageProps {
-    params: {
+    params: Promise<{
         gameId: string;
-    };
+    }>;
 }
 
-export default function GamePage({params}: GamePageProps) {
-
-    const gameId = params.gameId;
+export default async function GamePage({ params }: GamePageProps) {
+    const { gameId } = await params;
 
     return (
         <div>


### PR DESCRIPTION
## Summary
- await dynamic route params in builder game pages before parsing IDs
- update the RGS game page to await params as required by Next.js 15

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e0f41be08332b870dad5ab72f752