### PR TITLE
Align plugin forms action buttons with games style

### DIFF
--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/edit/EditPluginForm.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/edit/EditPluginForm.tsx
@@ -192,13 +192,17 @@ const EditPluginForm = ({ plugin }: EditPluginFormProps) => {
                     defaultValue={plugin.description}
                 />
             </div>
-            <div className="flex justify-end">
+            <div className="flex items-center gap-3">
+                <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "Saving..." : "Save changes"}
+                </Button>
                 <Button
-                    type="submit"
-                    className="min-w-32 justify-center"
+                    type="button"
+                    variant="outline"
+                    onClick={() => router.push(`/builder/plugins/${plugin.id}`)}
                     disabled={isSubmitting}
                 >
-                    {isSubmitting ? "Saving..." : "Save changes"}
+                    Cancel
                 </Button>
             </div>
         </form>

--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/versions/[versionId]/edit/EditPluginVersionForm.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/versions/[versionId]/edit/EditPluginVersionForm.tsx
@@ -157,13 +157,17 @@ const EditPluginVersionForm = ({ pluginId, pluginVersion }: EditPluginVersionFor
                     hint={errors.configuration}
                 />
             </div>
-            <div className="flex justify-end">
+            <div className="flex items-center gap-3">
+                <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "Saving..." : "Save changes"}
+                </Button>
                 <Button
-                    type="submit"
-                    className="min-w-32 justify-center"
+                    type="button"
+                    variant="outline"
+                    onClick={() => router.push(`/builder/plugins/${pluginId}`)}
                     disabled={isSubmitting}
                 >
-                    {isSubmitting ? "Saving..." : "Save changes"}
+                    Cancel
                 </Button>
             </div>
         </form>

--- a/src/app/(admin)/(builder)/builder/plugins/[pluginId]/versions/new/NewPluginVersionForm.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/[pluginId]/versions/new/NewPluginVersionForm.tsx
@@ -152,13 +152,17 @@ const NewPluginVersionForm = ({pluginId}: NewPluginVersionFormProps) => {
                     hint={errors.configuration}
                 />
             </div>
-            <div className="flex justify-end">
+            <div className="flex items-center gap-3">
+                <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "Creating..." : "Create version"}
+                </Button>
                 <Button
-                    type="submit"
-                    className="min-w-32 justify-center"
+                    type="button"
+                    variant="outline"
+                    onClick={() => router.push(`/builder/plugins/${pluginId}`)}
                     disabled={isSubmitting}
                 >
-                    {isSubmitting ? "Creating..." : "Create version"}
+                    Cancel
                 </Button>
             </div>
         </form>

--- a/src/app/(admin)/(builder)/builder/plugins/new/NewPluginForm.tsx
+++ b/src/app/(admin)/(builder)/builder/plugins/new/NewPluginForm.tsx
@@ -225,13 +225,17 @@ const NewPluginForm = () => {
                     rows={4}
                 />
             </div>
-            <div className="flex justify-end">
+            <div className="flex items-center gap-3">
+                <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "Creating..." : "Create plugin"}
+                </Button>
                 <Button
-                    type="submit"
-                    className="min-w-32 justify-center"
+                    type="button"
+                    variant="outline"
+                    onClick={() => router.push("/builder/plugins")}
                     disabled={isSubmitting}
                 >
-                    {isSubmitting ? "Creating..." : "Create plugin"}
+                    Cancel
                 </Button>
             </div>
         </form>


### PR DESCRIPTION
## Summary
- left-align plugin create/edit form actions to match game configuration styling
- add cancel buttons for plugin and version forms that navigate back to plugin details or list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e360cae0833293277ba1568f64a5