### PR TITLE
Add symbol management to game configuration details page

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/SymbolsCard.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/SymbolsCard.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import {
+  ChangeEvent,
+  Dispatch,
+  FormEvent,
+  SetStateAction,
+  useMemo,
+  useState,
+} from "react";
+import { useRouter } from "next/navigation";
+
+import ComponentCard from "@/components/common/ComponentCard";
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import TextArea from "@/components/form/input/TextArea";
+import Button from "@/components/ui/button/Button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { createSymbol } from "@/lib/symbols/createSymbol";
+import { deleteSymbol } from "@/lib/symbols/deleteSymbol";
+import { GameSymbol, SYMBOL_TYPES, SymbolType } from "@/lib/symbols/symbolType";
+import { updateSymbol } from "@/lib/symbols/updateSymbol";
+import { showToast } from "@/lib/toastStore";
+
+interface SymbolsCardProps {
+  configurationId: number;
+  symbols: GameSymbol[];
+}
+
+type FormField = "name" | "type";
+
+type FormErrors = Partial<Record<FormField, string>>;
+
+const formatError = (errors: FormErrors, field: FormField) =>
+  Boolean(errors[field]);
+
+const getErrorHint = (errors: FormErrors, field: FormField) => errors[field];
+
+const clearErrorIfNeeded = (
+  setErrors: Dispatch<SetStateAction<FormErrors>>,
+  field: FormField,
+  value: string
+) => {
+  const trimmedValue = value.trim();
+
+  setErrors((previousErrors) => {
+    if (!previousErrors[field] || !trimmedValue.length) {
+      return previousErrors;
+    }
+
+    const updated: FormErrors = { ...previousErrors };
+    delete updated[field];
+    return updated;
+  });
+};
+
+const SymbolsCard = ({ configurationId, symbols }: SymbolsCardProps) => {
+  const router = useRouter();
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createErrors, setCreateErrors] = useState<FormErrors>({});
+  const [isCreateSubmitting, setIsCreateSubmitting] = useState(false);
+
+  const [editingSymbol, setEditingSymbol] = useState<GameSymbol | null>(null);
+  const [editErrors, setEditErrors] = useState<FormErrors>({});
+  const [isEditSubmitting, setIsEditSubmitting] = useState(false);
+
+  const symbolTypeOptions = useMemo(() => SYMBOL_TYPES, []);
+
+  const handleAddSymbolClick = () => {
+    setIsCreateOpen((previous) => {
+      const next = !previous;
+      if (next) {
+        setEditingSymbol(null);
+      }
+      return next;
+    });
+    setCreateErrors({});
+  };
+
+  const handleCreateInputChange = (field: FormField) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      clearErrorIfNeeded(setCreateErrors, field, event.target.value);
+    };
+
+  const handleCreateSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    clearErrorIfNeeded(setCreateErrors, "type", event.target.value);
+  };
+
+  const handleEditInputChange = (field: FormField) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      clearErrorIfNeeded(setEditErrors, field, event.target.value);
+    };
+
+  const handleEditSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    clearErrorIfNeeded(setEditErrors, "type", event.target.value);
+  };
+
+  const handleCreateSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isCreateSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const name = String(formData.get("name") ?? "").trim();
+    const description = String(formData.get("description") ?? "").trim();
+    const typeValue = String(formData.get("type") ?? "").trim();
+
+    const validationErrors: FormErrors = {};
+
+    if (!name.length) {
+      validationErrors.name = "This field is required.";
+    }
+
+    if (!typeValue.length) {
+      validationErrors.type = "This field is required.";
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      setCreateErrors(validationErrors);
+      return;
+    }
+
+    setCreateErrors({});
+    setIsCreateSubmitting(true);
+
+    try {
+      await createSymbol({
+        gameConfigurationId: configurationId,
+        name,
+        description: description.length ? description : undefined,
+        type: typeValue as SymbolType,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Symbol created",
+        message: `${name} has been created successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      form.reset();
+      setIsCreateOpen(false);
+      router.refresh();
+    } catch (error) {
+      console.error("Failed to create symbol", error);
+    } finally {
+      setIsCreateSubmitting(false);
+    }
+  };
+
+  const handleEditSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!editingSymbol || isEditSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const name = String(formData.get("name") ?? "").trim();
+    const description = String(formData.get("description") ?? "").trim();
+    const typeValue = String(formData.get("type") ?? "").trim();
+
+    const validationErrors: FormErrors = {};
+
+    if (!name.length) {
+      validationErrors.name = "This field is required.";
+    }
+
+    if (!typeValue.length) {
+      validationErrors.type = "This field is required.";
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      setEditErrors(validationErrors);
+      return;
+    }
+
+    setEditErrors({});
+    setIsEditSubmitting(true);
+
+    try {
+      await updateSymbol(editingSymbol.id, {
+        name,
+        description: description.length ? description : undefined,
+        type: typeValue as SymbolType,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Symbol updated",
+        message: `${name} has been updated successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      setEditingSymbol(null);
+      router.refresh();
+    } catch (error) {
+      console.error(`Failed to update symbol ${editingSymbol.id}`, error);
+    } finally {
+      setIsEditSubmitting(false);
+    }
+  };
+
+  const handleCancelCreate = () => {
+    setIsCreateOpen(false);
+    setCreateErrors({});
+  };
+
+  const handleEditSymbol = (symbol: GameSymbol) => {
+    setEditingSymbol(symbol);
+    setEditErrors({});
+    setIsCreateOpen(false);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingSymbol(null);
+    setEditErrors({});
+  };
+
+  const handleDeleteSymbol = async (symbol: GameSymbol) => {
+    const confirmed = window.confirm("If user sure to delete?");
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await deleteSymbol(symbol.id);
+
+      showToast({
+        variant: "success",
+        title: "Symbol deleted",
+        message: `${symbol.name} has been removed successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      if (editingSymbol?.id === symbol.id) {
+        setEditingSymbol(null);
+      }
+
+      router.refresh();
+    } catch (error) {
+      console.error(`Failed to delete symbol ${symbol.id}`, error);
+    }
+  };
+
+  return (
+    <ComponentCard
+      title="Symbols"
+      action={
+        <Button type="button" size="sm" onClick={handleAddSymbolClick}>
+          {isCreateOpen ? "Hide form" : "Add Symbol"}
+        </Button>
+      }
+    >
+      <div className="space-y-6">
+        {isCreateOpen && (
+          <form key="create" className="space-y-4" onSubmit={handleCreateSubmit} noValidate>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="new-symbol-name">
+                  Name<span className="text-error-500">*</span>
+                </Label>
+                <Input
+                  id="new-symbol-name"
+                  name="name"
+                  placeholder="Enter symbol name"
+                  required
+                  onChange={handleCreateInputChange("name")}
+                  error={formatError(createErrors, "name")}
+                  hint={getErrorHint(createErrors, "name")}
+                />
+              </div>
+              <div>
+                <Label htmlFor="new-symbol-type">
+                  Type<span className="text-error-500">*</span>
+                </Label>
+                <select
+                  id="new-symbol-type"
+                  name="type"
+                  defaultValue=""
+                  onChange={handleCreateSelectChange}
+                  className={`h-11 w-full appearance-none rounded-lg border bg-transparent px-4 py-2.5 text-sm shadow-theme-xs focus:outline-hidden focus:ring-3 dark:bg-gray-900 dark:focus:border-brand-800 ${
+                    formatError(createErrors, "type")
+                      ? "border-error-500 text-error-800 focus:border-error-500 focus:ring-error-500/10 dark:border-error-500 dark:text-error-400"
+                      : "border-gray-300 text-gray-800 focus:border-brand-300 focus:ring-brand-500/10 dark:border-gray-700 dark:text-white/90"
+                  }`}
+                  required
+                >
+                  <option value="" disabled>
+                    Select symbol type
+                  </option>
+                  {symbolTypeOptions.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+                {getErrorHint(createErrors, "type") && (
+                  <p className="mt-1.5 text-xs text-error-500">
+                    {getErrorHint(createErrors, "type")}
+                  </p>
+                )}
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="new-symbol-description">Description</Label>
+              <TextArea
+                id="new-symbol-description"
+                name="description"
+                rows={4}
+                placeholder="Add description"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={isCreateSubmitting}>
+                {isCreateSubmitting ? "Submitting..." : "Submit"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancelCreate}
+                disabled={isCreateSubmitting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        {editingSymbol && (
+          <form
+            key={editingSymbol.id}
+            className="space-y-4"
+            onSubmit={handleEditSubmit}
+            noValidate
+          >
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="edit-symbol-name">
+                  Name<span className="text-error-500">*</span>
+                </Label>
+                <Input
+                  id="edit-symbol-name"
+                  name="name"
+                  defaultValue={editingSymbol.name}
+                  placeholder="Enter symbol name"
+                  required
+                  onChange={handleEditInputChange("name")}
+                  error={formatError(editErrors, "name")}
+                  hint={getErrorHint(editErrors, "name")}
+                />
+              </div>
+              <div>
+                <Label htmlFor="edit-symbol-type">
+                  Type<span className="text-error-500">*</span>
+                </Label>
+                <select
+                  id="edit-symbol-type"
+                  name="type"
+                  defaultValue={editingSymbol.type}
+                  onChange={handleEditSelectChange}
+                  className={`h-11 w-full appearance-none rounded-lg border bg-transparent px-4 py-2.5 text-sm shadow-theme-xs focus:outline-hidden focus:ring-3 dark:bg-gray-900 dark:focus:border-brand-800 ${
+                    formatError(editErrors, "type")
+                      ? "border-error-500 text-error-800 focus:border-error-500 focus:ring-error-500/10 dark:border-error-500 dark:text-error-400"
+                      : "border-gray-300 text-gray-800 focus:border-brand-300 focus:ring-brand-500/10 dark:border-gray-700 dark:text-white/90"
+                  }`}
+                  required
+                >
+                  <option value="" disabled>
+                    Select symbol type
+                  </option>
+                  {symbolTypeOptions.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+                {getErrorHint(editErrors, "type") && (
+                  <p className="mt-1.5 text-xs text-error-500">
+                    {getErrorHint(editErrors, "type")}
+                  </p>
+                )}
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="edit-symbol-description">Description</Label>
+              <TextArea
+                id="edit-symbol-description"
+                name="description"
+                rows={4}
+                defaultValue={editingSymbol.description ?? ""}
+                placeholder="Add description"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={isEditSubmitting}>
+                {isEditSubmitting ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancelEdit}
+                disabled={isEditSubmitting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        <div className="overflow-x-auto">
+          {symbols.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              No symbols available for this configuration.
+            </p>
+          ) : (
+            <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <TableHeader className="bg-gray-50 dark:bg-gray-900/40">
+                <TableRow>
+                  <TableCell
+                    isHeader
+                    className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                  >
+                    ID
+                  </TableCell>
+                  <TableCell
+                    isHeader
+                    className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                  >
+                    Name
+                  </TableCell>
+                  <TableCell
+                    isHeader
+                    className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                  >
+                    Description
+                  </TableCell>
+                  <TableCell
+                    isHeader
+                    className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                  >
+                    Type
+                  </TableCell>
+                  <TableCell
+                    isHeader
+                    className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                  >
+                    Actions
+                  </TableCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {symbols.map((symbol) => (
+                  <TableRow key={symbol.id} className="hover:bg-gray-50 dark:hover:bg-gray-900/40">
+                    <TableCell className="px-4 py-2 text-sm font-medium text-gray-800 dark:text-white/90">
+                      {symbol.id}
+                    </TableCell>
+                    <TableCell className="px-4 py-2 text-sm font-medium text-gray-800 dark:text-white/90">
+                      {symbol.name}
+                    </TableCell>
+                    <TableCell className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">
+                      {symbol.description?.length ? symbol.description : "—"}
+                    </TableCell>
+                    <TableCell className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">
+                      {symbol.type}
+                    </TableCell>
+                    <TableCell className="px-4 py-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleEditSymbol(symbol)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="text-error-600"
+                          onClick={() => handleDeleteSymbol(symbol)}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </div>
+    </ComponentCard>
+  );
+};
+
+export default SymbolsCard;

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Metadata } from "next";
 
 import ComponentCard from "@/components/common/ComponentCard";
@@ -10,7 +11,7 @@ import { GamePlugin } from "@/lib/game-plugins/gamePluginType";
 import { fetchReelSets } from "@/lib/reel-sets/fetchReelSets";
 import { ReelSet } from "@/lib/reel-sets/reelSetType";
 import { fetchSymbols } from "@/lib/symbols/fetchSymbols";
-import { GameSymbol } from "@/lib/symbols/symbolType";
+import SymbolsCard from "./SymbolsCard";
 
 export const metadata: Metadata = {
   title: "FiG | Game configuration details",
@@ -48,47 +49,6 @@ const renderConfigurationValue = (value: string | null | undefined) => {
 const renderEmptyState = (message: string) => (
   <p className="text-sm text-gray-500">{message}</p>
 );
-
-const SymbolsTable = ({ symbols }: { symbols: GameSymbol[] }) => {
-  if (symbols.length === 0) {
-    return renderEmptyState("No symbols available for this configuration.");
-  }
-
-  return (
-    <div className="overflow-x-auto">
-      <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-        <TableHeader className="bg-gray-50 dark:bg-gray-900/40">
-          <TableRow>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              Name
-            </TableCell>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              Description
-            </TableCell>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              Type
-            </TableCell>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="divide-y divide-gray-200 dark:divide-gray-700">
-          {symbols.map((symbol) => (
-            <TableRow key={symbol.id} className="hover:bg-gray-50 dark:hover:bg-gray-900/40">
-              <TableCell className="px-4 py-2 text-sm font-medium text-gray-800 dark:text-white/90">
-                {symbol.name}
-              </TableCell>
-              <TableCell className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">
-                {symbol.description || "—"}
-              </TableCell>
-              <TableCell className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">
-                {symbol.type}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
-  );
-};
 
 const ReelSetsTable = ({ reelSets }: { reelSets: ReelSet[] }) => {
   if (reelSets.length === 0) {
@@ -198,7 +158,17 @@ export default async function GameConfigurationDetailsPage({
         ]}
       />
       <div className="space-y-6">
-        <ComponentCard title="Configuration details">
+        <ComponentCard
+          title="Configuration details"
+          action={
+            <Link
+              href={`/builder/games/${game.id}/configurations/${configuration.id}/edit`}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-500 px-5 py-3.5 text-sm font-medium text-white shadow-theme-xs transition hover:bg-brand-600"
+            >
+              Edit
+            </Link>
+          }
+        >
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
               <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
@@ -233,9 +203,10 @@ export default async function GameConfigurationDetailsPage({
           </div>
         </ComponentCard>
 
-        <ComponentCard title="Symbols">
-          <SymbolsTable symbols={symbols} />
-        </ComponentCard>
+        <SymbolsCard
+          configurationId={configuration.id}
+          symbols={symbols}
+        />
 
         <ComponentCard title="Reel sets">
           <ReelSetsTable reelSets={reelSets} />

--- a/src/lib/symbols/createSymbol.ts
+++ b/src/lib/symbols/createSymbol.ts
@@ -1,0 +1,24 @@
+import { fetchData } from "@/lib/apiClient";
+import { GameSymbol, SymbolType } from "@/lib/symbols/symbolType";
+
+export interface CreateSymbolPayload {
+  gameConfigurationId: number;
+  name: string;
+  description?: string;
+  type: SymbolType;
+}
+
+export const createSymbol = async (
+  payload: CreateSymbolPayload
+): Promise<GameSymbol> => {
+  return fetchData<GameSymbol>("/v1/symbols", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default createSymbol;

--- a/src/lib/symbols/deleteSymbol.ts
+++ b/src/lib/symbols/deleteSymbol.ts
@@ -1,0 +1,12 @@
+import { fetchData } from "@/lib/apiClient";
+
+export const deleteSymbol = async (symbolId: number): Promise<void> => {
+  await fetchData<void>(`/v1/symbols/${symbolId}`, {
+    method: "DELETE",
+    headers: {
+      accept: "*/*",
+    },
+  });
+};
+
+export default deleteSymbol;

--- a/src/lib/symbols/symbolType.ts
+++ b/src/lib/symbols/symbolType.ts
@@ -1,9 +1,22 @@
+export const SYMBOL_TYPES = [
+  "HIGH",
+  "LOW",
+  "SCATTER",
+  "MULTIPLIER",
+  "WILD",
+  "STICKY_WILD",
+  "JACKPOT",
+  "BONUS",
+] as const;
+
+export type SymbolType = (typeof SYMBOL_TYPES)[number];
+
 export interface GameSymbol {
   id: number;
   gameConfigurationId: number;
   name: string;
-  description: string;
-  type: string;
+  description: string | null;
+  type: SymbolType;
 }
 
 export interface SymbolsResponse {

--- a/src/lib/symbols/updateSymbol.ts
+++ b/src/lib/symbols/updateSymbol.ts
@@ -1,0 +1,24 @@
+import { fetchData } from "@/lib/apiClient";
+import { GameSymbol, SymbolType } from "@/lib/symbols/symbolType";
+
+export interface UpdateSymbolPayload {
+  name: string;
+  description?: string;
+  type: SymbolType;
+}
+
+export const updateSymbol = async (
+  symbolId: number,
+  payload: UpdateSymbolPayload
+): Promise<GameSymbol> => {
+  return fetchData<GameSymbol>(`/v1/symbols/${symbolId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default updateSymbol;


### PR DESCRIPTION
## Summary
- add a symbols card with inline create, update, and delete workflows, validation, and refreshed table including symbol IDs
- expose symbol API helpers and enums to support the new forms
- surface an edit button for game configuration details navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d317444f708332b6d65b751bdd467f