### PR TITLE
Refactor configuration cards with configurable tables

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/PluginsCard.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/PluginsCard.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import ComponentCard from "@/components/common/ComponentCard";
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import TextArea from "@/components/form/input/TextArea";
+import ConfigurableTable, {
+  TableConfig,
+} from "@/components/tables/ConfigurableTable";
+import Button from "@/components/ui/button/Button";
+import { createGamePlugin } from "@/lib/game-plugins/createGamePlugin";
+import { deleteGamePlugin } from "@/lib/game-plugins/deleteGamePlugin";
+import { GamePlugin } from "@/lib/game-plugins/gamePluginType";
+import { updateGamePlugin } from "@/lib/game-plugins/updateGamePlugin";
+import { showToast } from "@/lib/toastStore";
+
+interface PluginsCardProps {
+  configurationId: number;
+  plugins: GamePlugin[];
+}
+
+type CreateFormErrors = Partial<Record<"pluginId", string>>;
+
+type EditFormState = {
+  description: string;
+  configuration: string;
+};
+
+const PluginsCard = ({ configurationId, plugins }: PluginsCardProps) => {
+  const router = useRouter();
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createErrors, setCreateErrors] = useState<CreateFormErrors>({});
+  const [isCreateSubmitting, setIsCreateSubmitting] = useState(false);
+
+  const [editingPlugin, setEditingPlugin] = useState<GamePlugin | null>(null);
+  const [editState, setEditState] = useState<EditFormState>({
+    description: "",
+    configuration: "",
+  });
+  const [isEditSubmitting, setIsEditSubmitting] = useState(false);
+
+  const handleToggleCreate = () => {
+    setIsCreateOpen((previous) => {
+      const next = !previous;
+      if (next) {
+        setEditingPlugin(null);
+      }
+      return next;
+    });
+    setCreateErrors({});
+  };
+
+  const handleCreatePluginIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (createErrors.pluginId && event.target.value.trim().length > 0) {
+      setCreateErrors({});
+    }
+  };
+
+  const handleCreateSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isCreateSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const pluginIdRaw = String(formData.get("pluginId") ?? "").trim();
+    const description = String(formData.get("description") ?? "").trim();
+    const configurationValue = String(formData.get("configuration") ?? "").trim();
+
+    const pluginId = Number(pluginIdRaw);
+
+    if (!pluginIdRaw.length || !Number.isInteger(pluginId) || pluginId <= 0) {
+      setCreateErrors({ pluginId: "Enter a valid plugin identifier." });
+      return;
+    }
+
+    setIsCreateSubmitting(true);
+
+    try {
+      await createGamePlugin({
+        gameConfigurationId: configurationId,
+        pluginId,
+        description: description.length ? description : undefined,
+        configuration: configurationValue.length ? configurationValue : undefined,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Plugin added",
+        message: `Plugin ${pluginId} has been linked successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      form.reset();
+      setIsCreateOpen(false);
+      router.refresh();
+    } catch (error) {
+      console.error("Failed to create game plugin", error);
+    } finally {
+      setIsCreateSubmitting(false);
+    }
+  };
+
+  const handleEditSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!editingPlugin || isEditSubmitting) {
+      return;
+    }
+
+    setIsEditSubmitting(true);
+
+    try {
+      await updateGamePlugin(editingPlugin.id, {
+        description: editState.description.trim().length
+          ? editState.description.trim()
+          : undefined,
+        configuration: editState.configuration.trim().length
+          ? editState.configuration.trim()
+          : undefined,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Plugin updated",
+        message: `Plugin ${editingPlugin.pluginId} has been updated successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      setEditingPlugin(null);
+      setEditState({ description: "", configuration: "" });
+      router.refresh();
+    } catch (error) {
+      console.error(`Failed to update game plugin ${editingPlugin.id}`, error);
+    } finally {
+      setIsEditSubmitting(false);
+    }
+  };
+
+  const handleCancelCreate = () => {
+    setIsCreateOpen(false);
+    setCreateErrors({});
+  };
+
+  const handleCancelEdit = () => {
+    setEditingPlugin(null);
+    setEditState({ description: "", configuration: "" });
+  };
+
+  const handleEditPlugin = useCallback((plugin: GamePlugin) => {
+    setEditingPlugin(plugin);
+    setEditState({
+      description: plugin.description ?? "",
+      configuration: plugin.configuration ?? "",
+    });
+    setIsCreateOpen(false);
+  }, []);
+
+  const handleDeletePlugin = useCallback(
+    async (plugin: GamePlugin) => {
+      const confirmed = window.confirm("If user sure to delete?");
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        await deleteGamePlugin(plugin.id);
+
+        showToast({
+          variant: "success",
+          title: "Plugin removed",
+          message: `Plugin ${plugin.pluginId} has been removed successfully.`,
+          hideButtonLabel: "Dismiss",
+        });
+
+        if (editingPlugin?.id === plugin.id) {
+          setEditingPlugin(null);
+          setEditState({ description: "", configuration: "" });
+        }
+
+        router.refresh();
+      } catch (error) {
+        console.error(`Failed to delete game plugin ${plugin.id}`, error);
+      }
+    },
+    [editingPlugin, router]
+  );
+
+  const tableConfig = useMemo<TableConfig<GamePlugin>>(
+    () => ({
+      enablePagination: false,
+      enableSearch: false,
+      enableSorting: false,
+      getRowKey: (row) => row.id,
+      fields: [
+        {
+          key: "pluginId",
+          label: "Plugin ID",
+          dataKey: "pluginId",
+        },
+        {
+          key: "description",
+          label: "Description",
+          render: (row) =>
+            row.description && row.description.length > 0 ? (
+              <span className="block whitespace-pre-wrap text-left">{row.description}</span>
+            ) : (
+              "—"
+            ),
+        },
+        {
+          key: "configuration",
+          label: "Configuration",
+          render: (row) =>
+            row.configuration && row.configuration.length > 0 ? (
+              <span className="block whitespace-pre-wrap text-left">{row.configuration}</span>
+            ) : (
+              "—"
+            ),
+        },
+      ],
+      actions: {
+        align: "end",
+        edit: {
+          label: "Edit",
+          onClick: handleEditPlugin,
+        },
+        remove: {
+          label: "Delete",
+          onClick: handleDeletePlugin,
+          buttonProps: {
+            className: "text-error-600",
+          },
+        },
+      },
+    }),
+    [handleDeletePlugin, handleEditPlugin]
+  );
+
+  return (
+    <ComponentCard
+      title="Plugins"
+      action={
+        <Button type="button" size="sm" onClick={handleToggleCreate}>
+          {isCreateOpen ? "Hide form" : "Add plugin"}
+        </Button>
+      }
+    >
+      <div className="space-y-6">
+        {isCreateOpen && (
+          <form key="create" className="space-y-4" onSubmit={handleCreateSubmit} noValidate>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="new-plugin-id">
+                  Plugin ID<span className="text-error-500">*</span>
+                </Label>
+                <Input
+                  id="new-plugin-id"
+                  name="pluginId"
+                  type="number"
+                  placeholder="Enter plugin ID"
+                  required
+                  onChange={handleCreatePluginIdChange}
+                  error={Boolean(createErrors.pluginId)}
+                  hint={createErrors.pluginId}
+                />
+              </div>
+              <div>
+                <Label htmlFor="new-plugin-description">Description</Label>
+                <Input
+                  id="new-plugin-description"
+                  name="description"
+                  placeholder="Add description"
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="new-plugin-configuration">Configuration</Label>
+              <TextArea
+                id="new-plugin-configuration"
+                name="configuration"
+                rows={4}
+                placeholder="Add configuration"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={isCreateSubmitting}>
+                {isCreateSubmitting ? "Submitting..." : "Submit"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancelCreate}
+                disabled={isCreateSubmitting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        {editingPlugin && (
+          <form
+            key={editingPlugin.id}
+            className="space-y-4"
+            onSubmit={handleEditSubmit}
+            noValidate
+          >
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="edit-plugin-id">Plugin ID</Label>
+                <Input
+                  id="edit-plugin-id"
+                  name="pluginId"
+                  defaultValue={editingPlugin.pluginId}
+                  disabled
+                />
+              </div>
+              <div>
+                <Label htmlFor="edit-plugin-description">Description</Label>
+                <Input
+                  id="edit-plugin-description"
+                  name="description"
+                  defaultValue={editState.description}
+                  onChange={(event) =>
+                    setEditState((previous) => ({
+                      ...previous,
+                      description: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="edit-plugin-configuration">Configuration</Label>
+              <TextArea
+                id="edit-plugin-configuration"
+                name="configuration"
+                rows={4}
+                defaultValue={editState.configuration}
+                onChange={(value) =>
+                  setEditState((previous) => ({
+                    ...previous,
+                    configuration: value,
+                  }))
+                }
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={isEditSubmitting}>
+                {isEditSubmitting ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancelEdit}
+                disabled={isEditSubmitting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        <ConfigurableTable data={plugins} config={tableConfig} />
+      </div>
+    </ComponentCard>
+  );
+};
+
+export default PluginsCard;

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/ReelSetsCard.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/ReelSetsCard.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import ComponentCard from "@/components/common/ComponentCard";
+import Label from "@/components/form/Label";
+import Input from "@/components/form/input/InputField";
+import ConfigurableTable, {
+  TableConfig,
+} from "@/components/tables/ConfigurableTable";
+import Button from "@/components/ui/button/Button";
+import { createReelSet } from "@/lib/reel-sets/createReelSet";
+import { deleteReelSet } from "@/lib/reel-sets/deleteReelSet";
+import { ReelSet } from "@/lib/reel-sets/reelSetType";
+import { updateReelSet } from "@/lib/reel-sets/updateReelSet";
+import { showToast } from "@/lib/toastStore";
+
+interface ReelSetsCardProps {
+  configurationId: number;
+  reelSets: ReelSet[];
+}
+
+type FormErrors = Partial<Record<"reelSetKey", string>>;
+
+const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
+  const router = useRouter();
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createErrors, setCreateErrors] = useState<FormErrors>({});
+  const [isCreateSubmitting, setIsCreateSubmitting] = useState(false);
+
+  const [editingReelSet, setEditingReelSet] = useState<ReelSet | null>(null);
+  const [editErrors, setEditErrors] = useState<FormErrors>({});
+  const [isEditSubmitting, setIsEditSubmitting] = useState(false);
+
+  const handleToggleCreate = () => {
+    setIsCreateOpen((previous) => {
+      const next = !previous;
+      if (next) {
+        setEditingReelSet(null);
+      }
+      return next;
+    });
+    setCreateErrors({});
+  };
+
+  const handleCreateInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (createErrors.reelSetKey && event.target.value.trim().length > 0) {
+      setCreateErrors({});
+    }
+  };
+
+  const handleEditInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (editErrors.reelSetKey && event.target.value.trim().length > 0) {
+      setEditErrors({});
+    }
+  };
+
+  const handleCreateSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isCreateSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const reelSetKey = String(formData.get("reelSetKey") ?? "").trim();
+
+    if (!reelSetKey.length) {
+      setCreateErrors({ reelSetKey: "This field is required." });
+      return;
+    }
+
+    setIsCreateSubmitting(true);
+
+    try {
+      await createReelSet({
+        gameConfigurationId: configurationId,
+        reelSetKey,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Reel set created",
+        message: `${reelSetKey} has been created successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      form.reset();
+      setIsCreateOpen(false);
+      router.refresh();
+    } catch (error) {
+      console.error("Failed to create reel set", error);
+    } finally {
+      setIsCreateSubmitting(false);
+    }
+  };
+
+  const handleEditSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!editingReelSet || isEditSubmitting) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const reelSetKey = String(formData.get("reelSetKey") ?? "").trim();
+
+    if (!reelSetKey.length) {
+      setEditErrors({ reelSetKey: "This field is required." });
+      return;
+    }
+
+    setIsEditSubmitting(true);
+
+    try {
+      await updateReelSet(editingReelSet.id, {
+        gameConfigurationId: configurationId,
+        reelSetKey,
+      });
+
+      showToast({
+        variant: "success",
+        title: "Reel set updated",
+        message: `${reelSetKey} has been updated successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+
+      setEditingReelSet(null);
+      router.refresh();
+    } catch (error) {
+      console.error(`Failed to update reel set ${editingReelSet.id}`, error);
+    } finally {
+      setIsEditSubmitting(false);
+    }
+  };
+
+  const handleCancelCreate = () => {
+    setIsCreateOpen(false);
+    setCreateErrors({});
+  };
+
+  const handleCancelEdit = () => {
+    setEditingReelSet(null);
+    setEditErrors({});
+  };
+
+  const handleEditReelSet = useCallback((reelSet: ReelSet) => {
+    setEditingReelSet(reelSet);
+    setEditErrors({});
+    setIsCreateOpen(false);
+  }, []);
+
+  const handleDeleteReelSet = useCallback(
+    async (reelSet: ReelSet) => {
+      const confirmed = window.confirm("If user sure to delete?");
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        await deleteReelSet(reelSet.id);
+
+        showToast({
+          variant: "success",
+          title: "Reel set deleted",
+          message: `${reelSet.reelSetKey} has been removed successfully.`,
+          hideButtonLabel: "Dismiss",
+        });
+
+        if (editingReelSet?.id === reelSet.id) {
+          setEditingReelSet(null);
+        }
+
+        router.refresh();
+      } catch (error) {
+        console.error(`Failed to delete reel set ${reelSet.id}`, error);
+      }
+    },
+    [editingReelSet, router]
+  );
+
+  const tableConfig = useMemo<TableConfig<ReelSet>>(
+    () => ({
+      enablePagination: false,
+      enableSearch: false,
+      enableSorting: false,
+      getRowKey: (row) => row.id,
+      fields: [
+        {
+          key: "id",
+          label: "ID",
+          dataKey: "id",
+        },
+        {
+          key: "reelSetKey",
+          label: "Reel set key",
+          dataKey: "reelSetKey",
+        },
+      ],
+      actions: {
+        align: "end",
+        edit: {
+          label: "Edit",
+          onClick: handleEditReelSet,
+        },
+        remove: {
+          label: "Delete",
+          onClick: handleDeleteReelSet,
+          buttonProps: {
+            className: "text-error-600",
+          },
+        },
+      },
+    }),
+    [handleDeleteReelSet, handleEditReelSet]
+  );
+
+  return (
+    <ComponentCard
+      title="Reel sets"
+      action={
+        <Button type="button" size="sm" onClick={handleToggleCreate}>
+          {isCreateOpen ? "Hide form" : "Add reel set"}
+        </Button>
+      }
+    >
+      <div className="space-y-6">
+        {isCreateOpen && (
+          <form key="create" className="space-y-4" onSubmit={handleCreateSubmit} noValidate>
+            <div>
+              <Label htmlFor="new-reel-set-key">
+                Reel set key<span className="text-error-500">*</span>
+              </Label>
+              <Input
+                id="new-reel-set-key"
+                name="reelSetKey"
+                placeholder="Enter reel set key"
+                required
+                onChange={handleCreateInputChange}
+                error={Boolean(createErrors.reelSetKey)}
+                hint={createErrors.reelSetKey}
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={isCreateSubmitting}>
+                {isCreateSubmitting ? "Submitting..." : "Submit"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancelCreate}
+                disabled={isCreateSubmitting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        {editingReelSet && (
+          <form
+            key={editingReelSet.id}
+            className="space-y-4"
+            onSubmit={handleEditSubmit}
+            noValidate
+          >
+            <div>
+              <Label htmlFor="edit-reel-set-key">
+                Reel set key<span className="text-error-500">*</span>
+              </Label>
+              <Input
+                id="edit-reel-set-key"
+                name="reelSetKey"
+                defaultValue={editingReelSet.reelSetKey}
+                placeholder="Enter reel set key"
+                required
+                onChange={handleEditInputChange}
+                error={Boolean(editErrors.reelSetKey)}
+                hint={editErrors.reelSetKey}
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={isEditSubmitting}>
+                {isEditSubmitting ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancelEdit}
+                disabled={isEditSubmitting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        <ConfigurableTable data={reelSets} config={tableConfig} />
+      </div>
+    </ComponentCard>
+  );
+};
+
+export default ReelSetsCard;

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/page.tsx
@@ -3,14 +3,13 @@ import { Metadata } from "next";
 
 import ComponentCard from "@/components/common/ComponentCard";
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
-import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
 import { fetchGameConfiguration } from "@/lib/game-configurations/fetchGameConfiguration";
 import { fetchGameById } from "@/lib/games/fetchGameById";
 import { fetchGamePlugins } from "@/lib/game-plugins/fetchGamePlugins";
-import { GamePlugin } from "@/lib/game-plugins/gamePluginType";
 import { fetchReelSets } from "@/lib/reel-sets/fetchReelSets";
-import { ReelSet } from "@/lib/reel-sets/reelSetType";
 import { fetchSymbols } from "@/lib/symbols/fetchSymbols";
+import PluginsCard from "./PluginsCard";
+import ReelSetsCard from "./ReelSetsCard";
 import SymbolsCard from "./SymbolsCard";
 
 export const metadata: Metadata = {
@@ -43,86 +42,6 @@ const renderConfigurationValue = (value: string | null | undefined) => {
     <pre className="whitespace-pre-wrap break-words rounded-lg bg-gray-50 p-4 text-sm text-gray-700 dark:bg-gray-900/40 dark:text-gray-200">
       {value}
     </pre>
-  );
-};
-
-const renderEmptyState = (message: string) => (
-  <p className="text-sm text-gray-500">{message}</p>
-);
-
-const ReelSetsTable = ({ reelSets }: { reelSets: ReelSet[] }) => {
-  if (reelSets.length === 0) {
-    return renderEmptyState("No reel sets available for this configuration.");
-  }
-
-  return (
-    <div className="overflow-x-auto">
-      <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-        <TableHeader className="bg-gray-50 dark:bg-gray-900/40">
-          <TableRow>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              ID
-            </TableCell>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              Reel set key
-            </TableCell>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="divide-y divide-gray-200 dark:divide-gray-700">
-          {reelSets.map((reelSet) => (
-            <TableRow key={reelSet.id} className="hover:bg-gray-50 dark:hover:bg-gray-900/40">
-              <TableCell className="px-4 py-2 text-sm font-medium text-gray-800 dark:text-white/90">
-                {reelSet.id}
-              </TableCell>
-              <TableCell className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">
-                {reelSet.reelSetKey}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
-  );
-};
-
-const GamePluginsTable = ({ plugins }: { plugins: GamePlugin[] }) => {
-  if (plugins.length === 0) {
-    return renderEmptyState("No plugins associated with this configuration.");
-  }
-
-  return (
-    <div className="overflow-x-auto">
-      <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-        <TableHeader className="bg-gray-50 dark:bg-gray-900/40">
-          <TableRow>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              Plugin ID
-            </TableCell>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              Description
-            </TableCell>
-            <TableCell isHeader className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              Configuration
-            </TableCell>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="divide-y divide-gray-200 dark:divide-gray-700">
-          {plugins.map((plugin) => (
-            <TableRow key={plugin.id} className="hover:bg-gray-50 dark:hover:bg-gray-900/40">
-              <TableCell className="px-4 py-2 text-sm font-medium text-gray-800 dark:text-white/90">
-                {plugin.pluginId}
-              </TableCell>
-              <TableCell className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">
-                {plugin.description || "—"}
-              </TableCell>
-              <TableCell className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">
-                {plugin.configuration || "—"}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
   );
 };
 
@@ -208,13 +127,9 @@ export default async function GameConfigurationDetailsPage({
           symbols={symbols}
         />
 
-        <ComponentCard title="Reel sets">
-          <ReelSetsTable reelSets={reelSets} />
-        </ComponentCard>
+        <ReelSetsCard configurationId={configuration.id} reelSets={reelSets} />
 
-        <ComponentCard title="Plugins">
-          <GamePluginsTable plugins={plugins} />
-        </ComponentCard>
+        <PluginsCard configurationId={configuration.id} plugins={plugins} />
       </div>
     </div>
   );

--- a/src/components/tables/ConfigurableTable.tsx
+++ b/src/components/tables/ConfigurableTable.tsx
@@ -546,7 +546,7 @@ const ConfigurableTable = <T extends object>({
                           >
                             {actionsConfig?.edit && (
                               <Button
-                                size="sm"
+                                size="xs"
                                 variant={actionsConfig.edit.buttonProps?.variant ?? "outline"}
                                 className={actionsConfig.edit.buttonProps?.className}
                                 onClick={(event) => {
@@ -559,7 +559,7 @@ const ConfigurableTable = <T extends object>({
                             )}
                             {actionsConfig?.remove && (
                               <Button
-                                size="sm"
+                                size="xs"
                                 variant={actionsConfig.remove.buttonProps?.variant ?? "outline"}
                                 className={
                                   actionsConfig.remove.buttonProps?.className ?? "text-red-500"

--- a/src/components/ui/button/Button.tsx
+++ b/src/components/ui/button/Button.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 
 interface ButtonProps {
   children: ReactNode; // Button text or content
-  size?: "sm" | "md"; // Button size
+  size?: "xs" | "sm" | "md"; // Button size
   variant?: "primary" | "outline"; // Button variant
   startIcon?: ReactNode; // Icon before the text
   endIcon?: ReactNode; // Icon after the text
@@ -25,9 +25,10 @@ const Button: React.FC<ButtonProps> = ({
 }) => {
   // Size Classes
   const sizeClasses = {
-    sm: "px-4 py-3 text-sm",
+    xs: "px-3 py-2 text-xs",
+    sm: "px-4 py-2.5 text-sm",
     md: "px-5 py-3.5 text-sm",
-  };
+  } as const;
 
   // Variant Classes
   const variantClasses = {

--- a/src/lib/game-plugins/createGamePlugin.ts
+++ b/src/lib/game-plugins/createGamePlugin.ts
@@ -1,0 +1,24 @@
+import { fetchData } from "@/lib/apiClient";
+import { GamePlugin } from "@/lib/game-plugins/gamePluginType";
+
+export interface CreateGamePluginPayload {
+  gameConfigurationId: number;
+  pluginId: number;
+  description?: string;
+  configuration?: string;
+}
+
+export const createGamePlugin = async (
+  payload: CreateGamePluginPayload
+): Promise<GamePlugin> => {
+  return fetchData<GamePlugin>("/v1/game-plugins", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default createGamePlugin;

--- a/src/lib/game-plugins/deleteGamePlugin.ts
+++ b/src/lib/game-plugins/deleteGamePlugin.ts
@@ -1,0 +1,12 @@
+import { fetchData } from "@/lib/apiClient";
+
+export const deleteGamePlugin = async (id: number): Promise<void> => {
+  await fetchData<void>(`/v1/game-plugins/${id}`, {
+    method: "DELETE",
+    headers: {
+      accept: "*/*",
+    },
+  });
+};
+
+export default deleteGamePlugin;

--- a/src/lib/game-plugins/updateGamePlugin.ts
+++ b/src/lib/game-plugins/updateGamePlugin.ts
@@ -1,0 +1,23 @@
+import { fetchData } from "@/lib/apiClient";
+import { GamePlugin } from "@/lib/game-plugins/gamePluginType";
+
+export interface UpdateGamePluginPayload {
+  description?: string;
+  configuration?: string;
+}
+
+export const updateGamePlugin = async (
+  id: number,
+  payload: UpdateGamePluginPayload
+): Promise<GamePlugin> => {
+  return fetchData<GamePlugin>(`/v1/game-plugins/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default updateGamePlugin;

--- a/src/lib/reel-sets/createReelSet.ts
+++ b/src/lib/reel-sets/createReelSet.ts
@@ -1,0 +1,22 @@
+import { fetchData } from "@/lib/apiClient";
+import { ReelSet } from "@/lib/reel-sets/reelSetType";
+
+export interface CreateReelSetPayload {
+  gameConfigurationId: number;
+  reelSetKey: string;
+}
+
+export const createReelSet = async (
+  payload: CreateReelSetPayload
+): Promise<ReelSet> => {
+  return fetchData<ReelSet>("/v1/reel-sets", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default createReelSet;

--- a/src/lib/reel-sets/deleteReelSet.ts
+++ b/src/lib/reel-sets/deleteReelSet.ts
@@ -1,0 +1,12 @@
+import { fetchData } from "@/lib/apiClient";
+
+export const deleteReelSet = async (id: number): Promise<void> => {
+  await fetchData<void>(`/v1/reel-sets/${id}`, {
+    method: "DELETE",
+    headers: {
+      accept: "*/*",
+    },
+  });
+};
+
+export default deleteReelSet;

--- a/src/lib/reel-sets/updateReelSet.ts
+++ b/src/lib/reel-sets/updateReelSet.ts
@@ -1,0 +1,23 @@
+import { fetchData } from "@/lib/apiClient";
+import { ReelSet } from "@/lib/reel-sets/reelSetType";
+
+export interface UpdateReelSetPayload {
+  gameConfigurationId: number;
+  reelSetKey: string;
+}
+
+export const updateReelSet = async (
+  id: number,
+  payload: UpdateReelSetPayload
+): Promise<ReelSet> => {
+  return fetchData<ReelSet>(`/v1/reel-sets/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "*/*",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default updateReelSet;


### PR DESCRIPTION
## Summary
- replace manual tables on the game configuration details page with configurable table based cards
- add dedicated cards for symbols, reel sets, and plugins that provide CRUD actions
- add REST clients for reel sets and game plugins and tweak shared button sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d31e909a688332bd3f7a8a59ba43ec