### PR TITLE
Add edit action to builder game details page

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/page.tsx
@@ -46,7 +46,17 @@ export default async function GamePage({ params }: GamePageProps) {
         ]}
       />
       <div className="space-y-6">
-        <ComponentCard title="Game details">
+        <ComponentCard
+          title="Game details"
+          action={
+            <Link
+              href={`/builder/games/${game.id}/edit`}
+              className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white shadow-theme-xs transition-colors hover:bg-brand-600"
+            >
+              Edit
+            </Link>
+          }
+        >
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
               <p className="text-sm font-medium text-gray-500 dark:text-gray-400">ID</p>


### PR DESCRIPTION
## Summary
- add an edit button to the builder game details card matching other detail pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3294018fc8332b5df3383cb74d811