### PR TITLE
Fix fetchReels to return paginated content

### DIFF
--- a/src/lib/reels/fetchReels.ts
+++ b/src/lib/reels/fetchReels.ts
@@ -1,8 +1,17 @@
 import { Reel } from "@/lib/reels/reelType";
 import { fetchData } from "@/lib/apiClient";
 
+interface ReelsResponse {
+  content: Reel[];
+  totalElements: number;
+  page: number;
+  size: number;
+}
+
 export const fetchReels = async (reelSetId: number) => {
   const params = new URLSearchParams({ reelSetId: String(reelSetId) });
 
-  return fetchData<Reel[]>(`/v1/reels?${params.toString()}`);
+  const { content } = await fetchData<ReelsResponse>(`/v1/reels?${params.toString()}`);
+
+  return Array.isArray(content) ? content : [];
 };


### PR DESCRIPTION
## Summary
- update the reels API client to account for the paginated response payload
- guard against missing content by defaulting to an empty list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d338e1b12083329451a8803c074d6d