### PR TITLE
Redesign reel sets card with inline reels management

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/ReelSetsCard.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/ReelSetsCard.tsx
@@ -1,15 +1,26 @@
+
 "use client";
 
-import { ChangeEvent, FormEvent, useCallback, useMemo, useState } from "react";
+import {
+  ChangeEvent,
+  FormEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 
 import ComponentCard from "@/components/common/ComponentCard";
 import Label from "@/components/form/Label";
 import Input from "@/components/form/input/InputField";
-import ConfigurableTable, {
-  TableConfig,
-} from "@/components/tables/ConfigurableTable";
+import TextArea from "@/components/form/input/TextArea";
+import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
 import Button from "@/components/ui/button/Button";
+import { createReel } from "@/lib/reels/createReel";
+import { deleteReel } from "@/lib/reels/deleteReel";
+import { fetchReels } from "@/lib/reels/fetchReels";
+import { Reel } from "@/lib/reels/reelType";
+import { updateReel } from "@/lib/reels/updateReel";
 import { createReelSet } from "@/lib/reel-sets/createReelSet";
 import { deleteReelSet } from "@/lib/reel-sets/deleteReelSet";
 import { ReelSet } from "@/lib/reel-sets/reelSetType";
@@ -23,6 +34,176 @@ interface ReelSetsCardProps {
 
 type FormErrors = Partial<Record<"reelSetKey", string>>;
 
+interface ReelListState {
+  content: Reel[];
+  totalElements: number;
+  page: number;
+  size: number;
+  isLoading: boolean;
+  hasLoaded: boolean;
+  error?: string;
+}
+
+interface ReelFormState {
+  mode: "create" | "edit";
+  reelSet: ReelSet;
+  reel?: Reel;
+}
+
+interface ReelFormSuccessOptions {
+  refreshToFirstPage?: boolean;
+}
+
+const DEFAULT_REELS_PAGE_SIZE = 10;
+
+const formatSymbolPreview = (symbolIds: number[]) => {
+  if (!symbolIds.length) {
+    return "—";
+  }
+
+  const preview = symbolIds.slice(0, 20).join(", ");
+  return symbolIds.length > 20 ? `${preview}…` : preview;
+};
+
+const computeTotalPages = (state?: ReelListState) => {
+  if (!state || state.size <= 0) {
+    return 1;
+  }
+
+  const totalPages = Math.ceil(state.totalElements / state.size);
+  return totalPages > 0 ? totalPages : 1;
+};
+
+interface ReelFormProps {
+  state: ReelFormState;
+  onCancel: () => void;
+  onSuccess: (options?: ReelFormSuccessOptions) => Promise<void> | void;
+}
+
+const ReelForm = ({ state, onCancel, onSuccess }: ReelFormProps) => {
+  const { mode, reelSet, reel } = state;
+  const [value, setValue] = useState(() => reel?.symbolIds.join(", ") ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleValueChange = (nextValue: string) => {
+    if (error) {
+      setError(null);
+    }
+
+    setValue(nextValue);
+  };
+
+  const parseSymbolIds = (input: string): number[] | null => {
+    const tokens = input
+      .split(/[\s,]+/)
+      .map((token) => token.trim())
+      .filter(Boolean);
+
+    if (!tokens.length) {
+      return [];
+    }
+
+    const parsed: number[] = [];
+    for (const token of tokens) {
+      const numericValue = Number(token);
+
+      if (!Number.isFinite(numericValue) || !Number.isInteger(numericValue)) {
+        return null;
+      }
+
+      parsed.push(numericValue);
+    }
+
+    return parsed;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const parsedSymbolIds = parseSymbolIds(value);
+
+    if (!parsedSymbolIds || parsedSymbolIds.length === 0) {
+      setError("Enter at least one valid symbol ID.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      if (mode === "create") {
+        await createReel({
+          reelSetId: reelSet.id,
+          symbolIds: parsedSymbolIds,
+        });
+
+        showToast({
+          variant: "success",
+          title: "Reel created",
+          message: `A reel has been added to ${reelSet.reelSetKey}.`,
+          hideButtonLabel: "Dismiss",
+        });
+
+        await onSuccess({ refreshToFirstPage: true });
+      } else if (reel) {
+        await updateReel(reel.id, { symbolIds: parsedSymbolIds });
+
+        showToast({
+          variant: "success",
+          title: "Reel updated",
+          message: `Reel ${reel.id} has been updated successfully.`,
+          hideButtonLabel: "Dismiss",
+        });
+
+        await onSuccess();
+      }
+    } catch (error) {
+      console.error("Failed to submit reel form", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const submitLabel = mode === "create" ? "Add reel" : "Save";
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+      <div>
+        <Label htmlFor={`reel-symbol-ids-${reelSet.id}`}>
+          Symbol IDs<span className="text-error-500">*</span>
+        </Label>
+        <TextArea
+          id={`reel-symbol-ids-${reelSet.id}`}
+          name="symbolIds"
+          rows={4}
+          value={value}
+          onChange={handleValueChange}
+          placeholder="Enter comma or space separated symbol IDs"
+          error={Boolean(error)}
+          hint={error ?? "Separate IDs with commas or spaces."}
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Submitting..." : submitLabel}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
 const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
   const router = useRouter();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -32,6 +213,52 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
   const [editingReelSet, setEditingReelSet] = useState<ReelSet | null>(null);
   const [editErrors, setEditErrors] = useState<FormErrors>({});
   const [isEditSubmitting, setIsEditSubmitting] = useState(false);
+
+  const [expandedReelSets, setExpandedReelSets] = useState<Set<number>>(
+    () => new Set()
+  );
+  const [reelStates, setReelStates] = useState<Record<number, ReelListState>>({});
+  const [activeReelForm, setActiveReelForm] = useState<ReelFormState | null>(null);
+
+  useEffect(() => {
+    setExpandedReelSets((previous) => {
+      const next = new Set<number>();
+      const validIds = new Set(reelSets.map((set) => set.id));
+
+      previous.forEach((id) => {
+        if (validIds.has(id)) {
+          next.add(id);
+        }
+      });
+
+      return next;
+    });
+
+    setReelStates((previous) => {
+      const next: Record<number, ReelListState> = {};
+      const validIds = new Set(reelSets.map((set) => set.id));
+
+      for (const id of validIds) {
+        if (previous[id]) {
+          next[id] = previous[id];
+        }
+      }
+
+      return next;
+    });
+
+    setActiveReelForm((previous) => {
+      if (!previous) {
+        return previous;
+      }
+
+      const exists = reelSets.some(
+        (reelSet) => reelSet.id === previous.reelSet.id
+      );
+
+      return exists ? previous : null;
+    });
+  }, [reelSets]);
 
   const handleToggleCreate = () => {
     setIsCreateOpen((previous) => {
@@ -55,6 +282,75 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
       setEditErrors({});
     }
   };
+
+  const loadReels = useCallback(
+    async (reelSetId: number, page?: number) => {
+      const existingState = reelStates[reelSetId];
+      const targetPage = page ?? existingState?.page ?? 0;
+      const pageSize = existingState?.size ?? DEFAULT_REELS_PAGE_SIZE;
+
+      if (existingState?.isLoading && existingState.page === targetPage) {
+        return;
+      }
+
+      setReelStates((previous) => ({
+        ...previous,
+        [reelSetId]: {
+          content: existingState?.content ?? [],
+          totalElements: existingState?.totalElements ?? 0,
+          page: targetPage,
+          size: pageSize,
+          isLoading: true,
+          hasLoaded: existingState?.hasLoaded ?? false,
+          error: undefined,
+        },
+      }));
+
+      try {
+        const response = await fetchReels({
+          reelSetId,
+          page: targetPage,
+          size: pageSize,
+        });
+
+        setReelStates((previous) => ({
+          ...previous,
+          [reelSetId]: {
+            content: response.content ?? [],
+            totalElements: response.totalElements,
+            page: response.page,
+            size: response.size,
+            isLoading: false,
+            hasLoaded: true,
+            error: undefined,
+          },
+        }));
+      } catch (error) {
+        console.error(`Failed to load reels for reel set ${reelSetId}`, error);
+
+        showToast({
+          variant: "error",
+          title: "Failed to load reels",
+          message: "Unable to load reels. Please try again.",
+          hideButtonLabel: "Dismiss",
+        });
+
+        setReelStates((previous) => ({
+          ...previous,
+          [reelSetId]: {
+            content: existingState?.content ?? [],
+            totalElements: existingState?.totalElements ?? 0,
+            page: targetPage,
+            size: pageSize,
+            isLoading: false,
+            hasLoaded: existingState?.hasLoaded ?? false,
+            error: "Unable to load reels. Please try again.",
+          },
+        }));
+      }
+    },
+    [reelStates]
+  );
 
   const handleCreateSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -147,15 +443,32 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
     setEditErrors({});
   };
 
-  const handleEditReelSet = useCallback((reelSet: ReelSet) => {
-    setEditingReelSet(reelSet);
-    setEditErrors({});
-    setIsCreateOpen(false);
-  }, []);
+  const handleEditReelSet = useCallback(
+    (reelSet: ReelSet) => {
+      setEditingReelSet(reelSet);
+      setEditErrors({});
+      setIsCreateOpen(false);
+
+      setExpandedReelSets((previous) => {
+        if (previous.has(reelSet.id)) {
+          return previous;
+        }
+
+        const next = new Set(previous);
+        next.add(reelSet.id);
+        return next;
+      });
+
+      void loadReels(reelSet.id);
+    },
+    [loadReels]
+  );
 
   const handleDeleteReelSet = useCallback(
     async (reelSet: ReelSet) => {
-      const confirmed = window.confirm("If user sure to delete?");
+      const confirmed = window.confirm(
+        "Are you sure you want to delete this reel set?"
+      );
       if (!confirmed) {
         return;
       }
@@ -174,6 +487,30 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
           setEditingReelSet(null);
         }
 
+        setActiveReelForm((previous) =>
+          previous?.reelSet.id === reelSet.id ? null : previous
+        );
+
+        setExpandedReelSets((previous) => {
+          if (!previous.has(reelSet.id)) {
+            return previous;
+          }
+
+          const next = new Set(previous);
+          next.delete(reelSet.id);
+          return next;
+        });
+
+        setReelStates((previous) => {
+          if (!(reelSet.id in previous)) {
+            return previous;
+          }
+
+          const next = { ...previous };
+          delete next[reelSet.id];
+          return next;
+        });
+
         router.refresh();
       } catch (error) {
         console.error(`Failed to delete reel set ${reelSet.id}`, error);
@@ -182,97 +519,203 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
     [editingReelSet, router]
   );
 
-  const tableConfig = useMemo<TableConfig<ReelSet>>(
-    () => ({
-      enablePagination: false,
-      enableSearch: false,
-      enableSorting: false,
-      getRowKey: (row) => row.id,
-      fields: [
-        {
-          key: "id",
-          label: "ID",
-          dataKey: "id",
-        },
-        {
-          key: "reelSetKey",
-          label: "Reel set key",
-          dataKey: "reelSetKey",
-        },
-      ],
-      actions: {
-        align: "end",
-        edit: {
-          label: "Edit",
-          onClick: handleEditReelSet,
-        },
-        remove: {
-          label: "Delete",
-          onClick: handleDeleteReelSet,
-          buttonProps: {
-            className: "text-error-600",
-          },
-        },
-      },
-    }),
-    [handleDeleteReelSet, handleEditReelSet]
+  const handleToggleReels = useCallback(
+    (reelSet: ReelSet) => {
+      setExpandedReelSets((previous) => {
+        const next = new Set(previous);
+
+        if (next.has(reelSet.id)) {
+          next.delete(reelSet.id);
+        } else {
+          next.add(reelSet.id);
+        }
+
+        return next;
+      });
+
+      const isCurrentlyExpanded = expandedReelSets.has(reelSet.id);
+
+      if (isCurrentlyExpanded) {
+        setActiveReelForm((previous) =>
+          previous?.reelSet.id === reelSet.id ? null : previous
+        );
+      } else if (!reelStates[reelSet.id]?.hasLoaded) {
+        void loadReels(reelSet.id);
+      }
+    },
+    [expandedReelSets, loadReels, reelStates]
   );
 
-  return (
-    <ComponentCard
-      title="Reel sets"
-      action={
-        <Button type="button" size="sm" onClick={handleToggleCreate}>
-          {isCreateOpen ? "Hide form" : "Add reel set"}
-        </Button>
-      }
-    >
-      <div className="space-y-6">
-        {isCreateOpen && (
-          <form key="create" className="space-y-4" onSubmit={handleCreateSubmit} noValidate>
-            <div>
-              <Label htmlFor="new-reel-set-key">
-                Reel set key<span className="text-error-500">*</span>
-              </Label>
-              <Input
-                id="new-reel-set-key"
-                name="reelSetKey"
-                placeholder="Enter reel set key"
-                required
-                onChange={handleCreateInputChange}
-                error={Boolean(createErrors.reelSetKey)}
-                hint={createErrors.reelSetKey}
-              />
-            </div>
-            <div className="flex items-center gap-3">
-              <Button type="submit" disabled={isCreateSubmitting}>
-                {isCreateSubmitting ? "Submitting..." : "Submit"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleCancelCreate}
-                disabled={isCreateSubmitting}
-              >
-                Cancel
-              </Button>
-            </div>
-          </form>
-        )}
+  const handleAddReel = useCallback(
+    (reelSet: ReelSet) => {
+      setActiveReelForm({ mode: "create", reelSet });
 
-        {editingReelSet && (
-          <form
-            key={editingReelSet.id}
-            className="space-y-4"
-            onSubmit={handleEditSubmit}
-            noValidate
-          >
+      setExpandedReelSets((previous) => {
+        if (previous.has(reelSet.id)) {
+          return previous;
+        }
+
+        const next = new Set(previous);
+        next.add(reelSet.id);
+        return next;
+      });
+
+      void loadReels(reelSet.id);
+    },
+    [loadReels]
+  );
+
+  const handleEditReel = useCallback(
+    (reelSet: ReelSet, reel: Reel) => {
+      setActiveReelForm({ mode: "edit", reelSet, reel });
+
+      setExpandedReelSets((previous) => {
+        if (previous.has(reelSet.id)) {
+          return previous;
+        }
+
+        const next = new Set(previous);
+        next.add(reelSet.id);
+        return next;
+      });
+
+      if (!reelStates[reelSet.id]?.hasLoaded) {
+        void loadReels(reelSet.id);
+      }
+    },
+    [loadReels, reelStates]
+  );
+
+  const handleReelFormSuccess = useCallback(
+    async (reelSetId: number, options?: ReelFormSuccessOptions) => {
+      const currentState = reelStates[reelSetId];
+      const targetPage = options?.refreshToFirstPage
+        ? 0
+        : currentState?.page ?? 0;
+
+      await loadReels(reelSetId, targetPage);
+      setActiveReelForm(null);
+    },
+    [loadReels, reelStates]
+  );
+
+  const handleDeleteReel = useCallback(
+    async (reelSet: ReelSet, reel: Reel) => {
+      const confirmed = window.confirm(
+        "Are you sure you want to delete this reel?"
+      );
+
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        await deleteReel(reel.id);
+
+        showToast({
+          variant: "success",
+          title: "Reel deleted",
+          message: `Reel ${reel.id} has been removed successfully.`,
+          hideButtonLabel: "Dismiss",
+        });
+
+        if (activeReelForm?.reel?.id === reel.id) {
+          setActiveReelForm(null);
+        }
+
+        await loadReels(reelSet.id, 0);
+      } catch (error) {
+        console.error(`Failed to delete reel ${reel.id}`, error);
+      }
+    },
+    [activeReelForm, loadReels]
+  );
+
+  const handleReelsPageChange = useCallback(
+    (reelSetId: number, direction: "prev" | "next") => {
+      const state = reelStates[reelSetId];
+      if (!state || state.isLoading) {
+        return;
+      }
+
+      const totalPages = computeTotalPages(state);
+      const targetPage =
+        direction === "prev"
+          ? Math.max(0, state.page - 1)
+          : Math.min(totalPages - 1, state.page + 1);
+
+      if (targetPage === state.page) {
+        return;
+      }
+
+      void loadReels(reelSetId, targetPage);
+    },
+    [loadReels, reelStates]
+  );
+
+  const renderReelSetCard = (reelSet: ReelSet) => {
+    const isExpanded = expandedReelSets.has(reelSet.id);
+    const state = reelStates[reelSet.id];
+    const reels = state?.content ?? [];
+    const totalPages = computeTotalPages(state);
+    const currentPage = state ? state.page + 1 : 1;
+    const canGoPrev = state ? state.page > 0 && !state.isLoading : false;
+    const canGoNext = state
+      ? state.page + 1 < totalPages && !state.isLoading && state.totalElements > 0
+      : false;
+    const showInitialSkeleton = Boolean(state?.isLoading && !state.hasLoaded);
+    const showLoadingOverlay = Boolean(state?.isLoading && state.hasLoaded);
+    const displayIndexBase = (state?.page ?? 0) * (state?.size ?? DEFAULT_REELS_PAGE_SIZE);
+
+    return (
+      <ComponentCard
+        key={reelSet.id}
+        title={
+          <span className="flex items-center gap-3">
+            <span>{reelSet.reelSetKey}</span>
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+              ID: {reelSet.id}
+            </span>
+          </span>
+        }
+        action={
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => handleEditReelSet(reelSet)}
+            >
+              Edit
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="text-error-600 hover:text-error-700 dark:text-error-400 dark:hover:text-error-300"
+              onClick={() => handleDeleteReelSet(reelSet)}
+            >
+              Delete
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => handleToggleReels(reelSet)}
+            >
+              {isExpanded ? "Collapse" : "Expand"}
+            </Button>
+          </div>
+        }
+      >
+        {editingReelSet?.id === reelSet.id && (
+          <form className="space-y-4" onSubmit={handleEditSubmit} noValidate>
             <div>
-              <Label htmlFor="edit-reel-set-key">
+              <Label htmlFor={`edit-reel-set-key-${reelSet.id}`}>
                 Reel set key<span className="text-error-500">*</span>
               </Label>
               <Input
-                id="edit-reel-set-key"
+                id={`edit-reel-set-key-${reelSet.id}`}
                 name="reelSetKey"
                 defaultValue={editingReelSet.reelSetKey}
                 placeholder="Enter reel set key"
@@ -298,8 +741,212 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
           </form>
         )}
 
-        <ConfigurableTable data={reelSets} config={tableConfig} />
-      </div>
+        {isExpanded ? (
+          <div className="space-y-4">
+            {activeReelForm?.reelSet.id === reelSet.id && (
+              <ReelForm
+                state={activeReelForm}
+                onCancel={() => setActiveReelForm(null)}
+                onSuccess={(options) => handleReelFormSuccess(reelSet.id, options)}
+              />
+            )}
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <Button type="button" size="sm" onClick={() => handleAddReel(reelSet)}>
+                Add reel
+              </Button>
+              <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                <span>
+                  Page {Math.min(currentPage, totalPages)} of {totalPages}
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    onClick={() => handleReelsPageChange(reelSet.id, "prev")}
+                    disabled={!canGoPrev}
+                  >
+                    Prev
+                  </Button>
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    onClick={() => handleReelsPageChange(reelSet.id, "next")}
+                    disabled={!canGoNext}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            {showInitialSkeleton ? (
+              <div className="space-y-3 rounded-xl border border-dashed border-gray-200 p-4 dark:border-gray-700">
+                <div className="h-4 w-1/3 animate-pulse rounded bg-gray-100 dark:bg-white/10" />
+                <div className="h-10 w-full animate-pulse rounded bg-gray-100 dark:bg-white/10" />
+                <div className="h-10 w-full animate-pulse rounded bg-gray-100 dark:bg-white/10" />
+              </div>
+            ) : state?.error ? (
+              <div className="rounded-xl border border-error-200 bg-error-50 p-4 text-sm text-error-700 dark:border-error-700/60 dark:bg-error-500/10 dark:text-error-300">
+                <p>{state.error}</p>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  className="mt-3"
+                  onClick={() => loadReels(reelSet.id, state.page)}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : reels.length === 0 ? (
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                <span>No reels yet.</span>
+                <Button type="button" size="sm" onClick={() => handleAddReel(reelSet)}>
+                  Add reel
+                </Button>
+              </div>
+            ) : (
+              <div className="relative">
+                {showLoadingOverlay && (
+                  <div className="absolute inset-0 rounded-xl bg-white/60 backdrop-blur-sm dark:bg-gray-900/40" />
+                )}
+                <Table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
+                  <TableHeader className="bg-gray-50 dark:bg-white/[0.03]">
+                    <TableRow>
+                      <TableCell
+                        isHeader
+                        className="px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
+                        #
+                      </TableCell>
+                      <TableCell
+                        isHeader
+                        className="px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
+                        Length
+                      </TableCell>
+                      <TableCell
+                        isHeader
+                        className="px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
+                        Symbols
+                      </TableCell>
+                      <TableCell
+                        isHeader
+                        className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
+                        Actions
+                      </TableCell>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody className="divide-y divide-gray-200 dark:divide-gray-800">
+                    {reels.map((reel, index) => {
+                      const displayIndex = displayIndexBase + index + 1;
+                      return (
+                        <TableRow
+                          key={reel.id}
+                          className="bg-white dark:bg-white/[0.02]"
+                        >
+                          <TableCell className="px-3 py-3 font-medium text-gray-700 dark:text-white/80">
+                            {displayIndex}
+                          </TableCell>
+                          <TableCell className="px-3 py-3 text-gray-600 dark:text-gray-300">
+                            {reel.symbolIds.length}
+                          </TableCell>
+                          <TableCell className="px-3 py-3 text-gray-600 dark:text-gray-300">
+                            {formatSymbolPreview(reel.symbolIds)}
+                          </TableCell>
+                          <TableCell className="px-3 py-3">
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                type="button"
+                                size="xs"
+                                variant="outline"
+                                onClick={() => handleEditReel(reelSet, reel)}
+                              >
+                                Edit
+                              </Button>
+                              <Button
+                                type="button"
+                                size="xs"
+                                variant="outline"
+                                className="text-error-600 hover:text-error-700 dark:text-error-400 dark:hover:text-error-300"
+                                onClick={() => handleDeleteReel(reelSet, reel)}
+                              >
+                                Delete
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Expand to manage reels for this set.
+          </p>
+        )}
+      </ComponentCard>
+    );
+  };
+
+  return (
+    <ComponentCard
+      title="Reel sets"
+      action={
+        <Button type="button" size="sm" onClick={handleToggleCreate}>
+          {isCreateOpen ? "Hide form" : "Add reel set"}
+        </Button>
+      }
+    >
+      {isCreateOpen && (
+        <form className="space-y-4" onSubmit={handleCreateSubmit} noValidate>
+          <div>
+            <Label htmlFor="new-reel-set-key">
+              Reel set key<span className="text-error-500">*</span>
+            </Label>
+            <Input
+              id="new-reel-set-key"
+              name="reelSetKey"
+              placeholder="Enter reel set key"
+              required
+              onChange={handleCreateInputChange}
+              error={Boolean(createErrors.reelSetKey)}
+              hint={createErrors.reelSetKey}
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <Button type="submit" disabled={isCreateSubmitting}>
+              {isCreateSubmitting ? "Submitting..." : "Submit"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancelCreate}
+              disabled={isCreateSubmitting}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {reelSets.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No reel sets have been added yet.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {reelSets.map((reelSet) => renderReelSetCard(reelSet))}
+        </div>
+      )}
     </ComponentCard>
   );
 };

--- a/src/components/common/ComponentCard.tsx
+++ b/src/components/common/ComponentCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 interface ComponentCardProps {
-  title: string;
+  title: React.ReactNode;
   children: React.ReactNode;
   className?: string; // Additional custom classes for styling
   desc?: string; // Description text

--- a/src/lib/reels/createReel.ts
+++ b/src/lib/reels/createReel.ts
@@ -1,0 +1,21 @@
+import { fetchData } from "@/lib/apiClient";
+import { Reel } from "@/lib/reels/reelType";
+
+export interface CreateReelPayload {
+  reelSetId: number;
+  symbolIds: number[];
+}
+
+export const createReel = async (
+  payload: CreateReelPayload
+): Promise<Reel> => {
+  return fetchData<Reel>("/v1/reels", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default createReel;

--- a/src/lib/reels/deleteReel.ts
+++ b/src/lib/reels/deleteReel.ts
@@ -1,0 +1,9 @@
+import { fetchData } from "@/lib/apiClient";
+
+export const deleteReel = async (reelId: number): Promise<void> => {
+  await fetchData<void>(`/v1/reels/${reelId}`, {
+    method: "DELETE",
+  });
+};
+
+export default deleteReel;

--- a/src/lib/reels/fetchReels.ts
+++ b/src/lib/reels/fetchReels.ts
@@ -1,0 +1,32 @@
+import { fetchData } from "@/lib/apiClient";
+import { Reel, ReelsResponse } from "@/lib/reels/reelType";
+
+const normalizeReels = (response: ReelsResponse): Reel[] => {
+  return response.content ?? [];
+};
+
+interface FetchReelsParams {
+  reelSetId: number;
+  page?: number;
+  size?: number;
+}
+
+export const fetchReels = async ({
+  reelSetId,
+  page = 0,
+  size = 10,
+}: FetchReelsParams): Promise<ReelsResponse> => {
+  const response = await fetchData<ReelsResponse>(
+    `/v1/reels?reelSetId=${reelSetId}&page=${page}&size=${size}`,
+    {
+      cache: "no-store",
+    }
+  );
+
+  return {
+    ...response,
+    content: normalizeReels(response),
+  };
+};
+
+export default fetchReels;

--- a/src/lib/reels/reelType.ts
+++ b/src/lib/reels/reelType.ts
@@ -1,0 +1,12 @@
+export interface Reel {
+  id: number;
+  reelSetId: number;
+  symbolIds: number[];
+}
+
+export interface ReelsResponse {
+  content?: Reel[];
+  totalElements: number;
+  page: number;
+  size: number;
+}

--- a/src/lib/reels/updateReel.ts
+++ b/src/lib/reels/updateReel.ts
@@ -1,0 +1,21 @@
+import { fetchData } from "@/lib/apiClient";
+import { Reel } from "@/lib/reels/reelType";
+
+export interface UpdateReelPayload {
+  symbolIds: number[];
+}
+
+export const updateReel = async (
+  reelId: number,
+  payload: UpdateReelPayload
+): Promise<Reel> => {
+  return fetchData<Reel>(`/v1/reels/${reelId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+};
+
+export default updateReel;


### PR DESCRIPTION
## Summary
- redesign the configuration reel sets view to render per-set cards with lazy reel fetching, pagination, and inline forms for managing reels
- add client helpers for fetching and mutating reel resources used by the new UI
- allow ComponentCard headers to render richer title content to support the new badge layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d33cce5c1c8332b1c47577e221bb43