### PR TITLE
Support reel reordering and index updates

### DIFF
--- a/src/lib/reels/fetchReels.ts
+++ b/src/lib/reels/fetchReels.ts
@@ -2,7 +2,9 @@ import { fetchData } from "@/lib/apiClient";
 import { Reel, ReelsResponse } from "@/lib/reels/reelType";
 
 const normalizeReels = (response: ReelsResponse): Reel[] => {
-  return response.content ?? [];
+  return (response.content ?? [])
+    .filter((reel): reel is Reel => reel != null)
+    .sort((a, b) => a.index - b.index);
 };
 
 interface FetchReelsParams {

--- a/src/lib/reels/reelType.ts
+++ b/src/lib/reels/reelType.ts
@@ -1,6 +1,7 @@
 export interface Reel {
   id: number;
   reelSetId: number;
+  index: number;
   symbolIds: number[];
 }
 

--- a/src/lib/reels/updateReel.ts
+++ b/src/lib/reels/updateReel.ts
@@ -2,6 +2,7 @@ import { fetchData } from "@/lib/apiClient";
 import { Reel } from "@/lib/reels/reelType";
 
 export interface UpdateReelPayload {
+  index: number;
   symbolIds: number[];
 }
 


### PR DESCRIPTION
## Summary
- include reel indexes in the update payload and reel type, and normalize fetched reels by index
- add controls in the reel sets card to reorder reels, persist new positions, and guard pagination while saving
- ensure reel editing preserves index values when updating symbols

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d342a22e3c8332a457e3cf72051102