### PR TITLE
Update reel management UI and creation logic

### DIFF
--- a/src/lib/reels/createReel.ts
+++ b/src/lib/reels/createReel.ts
@@ -3,6 +3,7 @@ import { Reel } from "@/lib/reels/reelType";
 
 export interface CreateReelPayload {
   reelSetId: number;
+  index: number;
   symbolIds: number[];
 }
 


### PR DESCRIPTION
## Summary
- display reel IDs in the reels table and hide the new reel/save controls when the creation form is active
- assign a next sequential index when creating reels and expose the calculator to the form
- rename the reel creation trigger to "New reel"

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d3469fecd48332bf91886d4e1f5fa4