### PR TITLE
Adjust ReelSetsCard hint placement

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/ReelSetsCard.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/ReelSetsCard.tsx
@@ -848,10 +848,13 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
       <ComponentCard
         key={reelSet.id}
         title={
-          <span className="flex items-center gap-3">
+          <span className="flex flex-wrap items-center gap-3">
             <span>{reelSet.reelSetKey}</span>
             <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
               ID: {reelSet.id}
+            </span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              Expand to manage reels for this set.
             </span>
           </span>
         }
@@ -1110,11 +1113,7 @@ const ReelSetsCard = ({ configurationId, reelSets }: ReelSetsCardProps) => {
               </div>
             )}
           </div>
-        ) : (
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            Expand to manage reels for this set.
-          </p>
-        )}
+        ) : null}
       </ComponentCard>
     );
   };


### PR DESCRIPTION
## Summary
- surface the "Expand to manage reels for this set." hint next to the reel set ID in each card header
- remove the redundant collapsed state hint paragraph

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d34a35e25c8332bf0af8d425e628c2