### PR TITLE
Add trigger build button to configuration details

### DIFF
--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/TriggerGameBuildButton.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/TriggerGameBuildButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+
+import Button from "@/components/ui/button/Button";
+import { triggerGameBuild } from "@/lib/game-configurations/triggerGameBuild";
+import { showToast } from "@/lib/toastStore";
+
+interface TriggerGameBuildButtonProps {
+  configurationId: number;
+  configurationName: string;
+}
+
+const TriggerGameBuildButton = ({
+  configurationId,
+  configurationName,
+}: TriggerGameBuildButtonProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleClick = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await triggerGameBuild(configurationId);
+
+      showToast({
+        variant: "success",
+        title: "Build triggered",
+        message: `${configurationName} build has been triggered successfully.`,
+        hideButtonLabel: "Dismiss",
+      });
+    } catch (error) {
+      console.error(
+        `Failed to trigger build for configuration ${configurationId}`,
+        error
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Button type="button" onClick={handleClick} disabled={isSubmitting}>
+      {isSubmitting ? "Triggering..." : "Validate & Build"}
+    </Button>
+  );
+};
+
+export default TriggerGameBuildButton;

--- a/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/page.tsx
+++ b/src/app/(admin)/(builder)/builder/games/[gameId]/configurations/[configurationId]/page.tsx
@@ -11,6 +11,7 @@ import { fetchSymbols } from "@/lib/symbols/fetchSymbols";
 import PluginsCard from "./PluginsCard";
 import ReelSetsCard from "./ReelSetsCard";
 import SymbolsCard from "./SymbolsCard";
+import TriggerGameBuildButton from "./TriggerGameBuildButton";
 
 export const metadata: Metadata = {
   title: "FiG | Game configuration details",
@@ -79,12 +80,18 @@ export default async function GameConfigurationDetailsPage({
         <ComponentCard
           title="Configuration details"
           action={
-            <Link
-              href={`/builder/games/${game.id}/configurations/${configuration.id}/edit`}
-              className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-500 px-5 py-3.5 text-sm font-medium text-white shadow-theme-xs transition hover:bg-brand-600"
-            >
-              Edit
-            </Link>
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              <TriggerGameBuildButton
+                configurationId={configuration.id}
+                configurationName={configuration.name}
+              />
+              <Link
+                href={`/builder/games/${game.id}/configurations/${configuration.id}/edit`}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-500 px-5 py-3.5 text-sm font-medium text-white shadow-theme-xs transition hover:bg-brand-600"
+              >
+                Edit
+              </Link>
+            </div>
           }
         >
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/lib/game-configurations/triggerGameBuild.ts
+++ b/src/lib/game-configurations/triggerGameBuild.ts
@@ -1,0 +1,16 @@
+import { fetchData } from "@/lib/apiClient";
+
+export const triggerGameBuild = async (configurationId: number): Promise<void> => {
+  if (!Number.isInteger(configurationId) || configurationId <= 0) {
+    throw new Error("A valid configuration identifier is required");
+  }
+
+  await fetchData<void>(`/v1/trigger-game-build/${configurationId}`, {
+    method: "POST",
+    headers: {
+      accept: "*/*",
+    },
+  });
+};
+
+export default triggerGameBuild;


### PR DESCRIPTION
## Summary
- add a Validate & Build action to configuration details with a trigger button
- create a client button component that calls the trigger build endpoint and shows feedback
- add a reusable helper for triggering game builds via the API client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e196c9be308332b72d755444ba9cd6