### PR TITLE
Handle empty API responses in fetchData

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -128,8 +128,15 @@ export const fetchData = async <TResponse>(
     return undefined as TResponse;
   }
 
+  const responseText = await response.text();
+  const trimmedResponseText = responseText.trim();
+
+  if (!trimmedResponseText) {
+    return undefined as TResponse;
+  }
+
   try {
-    return (await response.json()) as TResponse;
+    return JSON.parse(trimmedResponseText) as TResponse;
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     const errorMessage = `Failed to parse JSON response from ${url}: ${reason}`;


### PR DESCRIPTION
## Summary
- treat empty successful API responses as having no payload to prevent JSON parsing errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e19a840da08332a3a6e34f20ac3216